### PR TITLE
Reverse Time

### DIFF
--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -299,7 +299,7 @@ end
         Delta = r^2 - 2 * M * r + a^2
 
         (
-            4 * Delta * M * a * r * v_phi * sin_theta^2 + sqrt(
+            4 * Delta * M * a * r * v_phi * sin_theta^2 - sqrt(
                 (
                     2 *
                     (6 * Delta^2 * M^2 * a^2 * r^2 + Delta^2 * M * Sigma * a^2 * r) *

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,15 +6,15 @@ using Test, ComputedGeodesicEquations
     u = [0.0, 100.0, π / 2.0, 0.0]
     v = [0.0, -1.0, 0.0, 1e-4]
 
-    @test BoyerLindquistCoords.null_constrain(u, v, M, a) ≈ -1.0204101936749481
+    @test BoyerLindquistCoords.null_constrain(u, v, M, a) ≈ 1.020402030409642
 
-    v[1] = -1.0204101936749481
+    v[1] = 1.020402030409642
     @test all(
         BoyerLindquistCoords.geodesic_eq(u, v, M, a) .≈ (
-            -0.0002083677190516319,
-            -1.014389097284123e-7,
-            5.0373193274816055e-26,
-            1.958148390240991e-6,
+            0.00020812117198812312,
+            - 1.9798090919204276e-8,
+            -4.9607974159635116e-26,
+            2.0414383391937405e-6,
         ),
     )
 


### PR DESCRIPTION
The null constraint for the BoyerLindquist coordinates was returning the backwards time direction -- changed to forward by adjusting the sign before the square root.