### PR TITLE
Remove Compat

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -66,9 +66,9 @@ version = "0.21.2"
 
 [[JuliaFormatter]]
 deps = ["CSTParser", "CommonMark", "DataStructures", "Pkg", "Tokenize"]
-git-tree-sha1 = "e7092df00019dab7ab81154df576c975fa6e47a3"
+git-tree-sha1 = "e1a91af84efba5228480bd20aeef1dd902d553cf"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "0.18.1"
+version = "0.19.2"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,6 @@ JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
-JuliaFormatter = "^0.18.0"
-Parameters = "^0.12.0"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
Remove the compatibility section for JuliaFormatter.jl and Parameters.jl to fix a dependency issue.

The compatibility should be revised at a later stage.