### PR TITLE
Jacobian Methods

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,34 +9,27 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[CSTParser]]
-deps = ["Tokenize"]
-git-tree-sha1 = "b2667530e42347b10c10ba6623cfebc09ac5c7b6"
-uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "3.2.4"
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "f9982ef575e19b0e5c7a98c6e75ee496c0f73a93"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.12.0"
 
-[[CommonMark]]
-deps = ["Crayons", "JSON", "URIs"]
-git-tree-sha1 = "393ac9df4eb085c2ab12005fc496dae2e1da344e"
-uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
-version = "0.8.3"
+[[ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "31d0151f5716b655421d9d75b7fa74cc4e744df2"
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.39.0"
+version = "3.41.0"
 
-[[Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
-uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
-
-[[DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.10"
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[Dates]]
 deps = ["Printf"]
@@ -46,9 +39,21 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
+[[DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "84083a5136b6abf426174a58325ffd159dd6d94f"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.9.1"
+
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
 
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -63,17 +68,22 @@ version = "0.1.0"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.2"
+[[InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.2"
 
-[[JuliaFormatter]]
-deps = ["CSTParser", "CommonMark", "DataStructures", "Pkg", "Tokenize"]
-git-tree-sha1 = "8b5c6eecd33eddc265db4bf71dcda1c9c0e96d33"
-uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "0.16.2"
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -95,8 +105,14 @@ uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.6"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -115,8 +131,27 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
+[[NaNMath]]
+git-tree-sha1 = "b086b7ea07f8e38cf122f5016af580881ac914fe"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.7"
+
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -129,15 +164,15 @@ git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.12.3"
 
-[[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "a8709b968a1ea6abc2dc1967cb1db6ac9a00dfb6"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.5"
-
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -148,8 +183,14 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -168,6 +209,18 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[[SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "8d0c8e3d0ff211d9ff4a0c2307d876c99d10bdf1"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.1.2"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "a635a9333989a094bddc9f940c04c549cd66afcf"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.3.4"
+
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -184,15 +237,11 @@ uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[Tokenize]]
-git-tree-sha1 = "0952c9cee34988092d73a5708780b3917166a0dd"
-uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.21"
-
-[[URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
+[[Tullio]]
+deps = ["ChainRulesCore", "DiffRules", "LinearAlgebra", "Requires"]
+git-tree-sha1 = "7830c974acc69437a3fee35dd7b510a74cbc862d"
+uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
+version = "0.3.3"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -209,6 +258,10 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComputedGeodesicEquations"
 uuid = "42910a5e-bdf1-4870-a538-dfa35571a56d"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 GeodesicBase = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,9 @@ version = "0.3.1"
 
 [deps]
 GeodesicBase = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 
 [compat]
 julia = "1.0"

--- a/README.md
+++ b/README.md
@@ -7,32 +7,16 @@ These include
 ## Kerr geometries
 
 - Boyer-Lindquist Coordinates
+- (planned) Kerr-Schild Cartesian Coordinates
+
+## Modified Kerr geometries
+
+- Johannsen-Psaltis Metric in Boyer-Lindquist Coordinates
 
 ## Schwarzschild geometries
 
 - Eddington-Finkelstein Coordinates
 
-## Usage
+## Other
 
-Each spacetime is an exported module, defining three functions:
-
-- acceleration components (out-of-place):
-```jl
-function geodesic_eq(u, v, args...)
-    # ...
-end
-```
-
-- acceleration components (in-place):
-```jl
-function geodesic_eq!(duv, u, v, args...)
-    # ...
-end
-```
-
-- time constraint equation (returns time component of a light-like vector)
-```jl
-function null_constrain(u, v, args...)
-    # ...
-end
-```
+- Morris-Thorne Wormhole

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -1,0 +1,36 @@
+using BenchmarkTools
+using StaticArrays 
+
+using ComputedGeodesicEquations
+
+randpos() = (rand(0.0:1000.0), rand(1.1:10.0), rand(0.1:π/1.1), rand(-π/3:π/3))
+
+us = [ SVector{4, Float64}([randpos()...]) for i in 1:1000 ]
+vs = [ SVector{4, Float64}([randpos()...]) for i in 1:1000 ]
+
+
+function runner(us, vs, m)
+    for (u, v) in zip(us, vs)
+        geodesic_eq(m, u, v)
+    end
+end
+
+
+suite = BenchmarkGroup()
+suite["regular"] = BenchmarkGroup()
+suite["jacobian"] = BenchmarkGroup()
+
+suite["regular"]["boyer-lindquist"] = @benchmarkable runner($us, $vs, m) setup=(m = BoyerLindquist())
+suite["jacobian"]["boyer-lindquist"] = @benchmarkable runner($us, $vs, m) setup=(m = BoyerLindquistJac())
+
+suite["regular"]["johannsen-psaltis"] = @benchmarkable runner($us, $vs, m) setup=(m = JohannsenPsaltis())
+suite["jacobian"]["johannsen-psaltis"] = @benchmarkable runner($us, $vs, m) setup=(m = JohannsenPsaltisJac())
+
+suite["regular"]["eddington-finkelstein"] = @benchmarkable runner($us, $vs, m) setup=(m = EddingtonFinkelstein())
+suite["jacobian"]["eddington-finkelstein"] = @benchmarkable runner($us, $vs, m) setup=(m = EddingtonFinkelsteinJac())
+
+suite["regular"]["morris-thorne"] = @benchmarkable runner($us, $vs, m) setup=(m = MorrisThorne())
+suite["jacobian"]["morris-thorne"] = @benchmarkable runner($us, $vs, m) setup=(m = MorrisThorneJac())
+
+tune!(suite)
+results = run(suite, verbose = true)

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -137,7 +137,12 @@ def make_jacobian_julia_function(jac, *args):
     matrix_strings = [to_julia_matrix(str(v)) for (_, v) in jac.items()]
 
     components = "\n".join(
-        [f"comp{i+1} = ComputedGeodesicEquations.@SMatrix {matrix_strings[i]}" for i in range(4)]
+        [
+            (f"comp{i+1} = ComputedGeodesicEquations.@SMatrix {matrix_strings[i]}" 
+            if matrix_strings[i] != 0 else 
+            f"comp{i+1} = zeros(ComputedGeodesicEquations.SMatrix{{4,4,Float64}})")
+            for i in range(4)
+        ]
     )
 
     arguments = ", ".join((str(i) for i in ['u', *args]))
@@ -201,7 +206,7 @@ end
 end
 
 geodesic_eq(m::{name}{{T}}, u, v) where {{T}} = {name}Coords.geodesic_eq(u, v, {struct_arguments})
-geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = jac_geodesic_eq(u, v, m)
+geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = jac_geodesic_eq(m, u, v)
 
 constrain(m::{name}{{T}}, u, v; μ::T=0.0) where {{T}} = {name}Coords.constrain(μ, u, v, {struct_arguments})
 

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -1,3 +1,5 @@
+from ast import arg
+import struct
 from sage.all import *
 import itertools
 
@@ -11,7 +13,7 @@ def __generate_geodesic_equations(g, vel):
     for (i, j) in indexprod(2):
         constrain_eq += g[i,j] * vel[i] * vel[j]
 
-    sols = (constrain_eq.expr()==mu^2).solve(vel[0])
+    sols = (constrain_eq.expr()==mu**2).solve(vel[0])
 
     cs = g.christoffel_symbols()
 
@@ -35,6 +37,23 @@ def generate_geodesic_equations_cartesian(g):
     vel = [vt, vx, vy, vz]
     return __generate_geodesic_equations(g, vel)
 
+def generate_jacobian_dict(g, coords):
+    jacobian_dict = {}
+    for symb in coords:
+        derivs = []
+        for i in range(4):
+            for j in range(4):
+                # simplify can't hurt i guess
+                derivs.append(simplify(g[i, j].diff(symb)))
+        # use matrix constructor to get "pretty print"
+        jacobian_dict[symb] = matrix(derivs, nrows=4, ncols=4)
+    return jacobian_dict
+
+def generate_jacobian_functions(g, coords):
+    ginv = g.inverse()
+    jacobian_dict = generate_jacobian_dict(g, coords)
+    return ginv, jacobian_dict
+
 def cache_functions(string):
     output = string.replace(
         "cos(theta)", "cos_theta"
@@ -42,8 +61,8 @@ def cache_functions(string):
         "sin(theta)", "sin_theta"
     )
     
-    funcs = """cos_theta = cos(θ)
-        sin_theta = sin(θ)
+    funcs = """cos_theta = cos(theta)
+        sin_theta = sin(theta)
     """
     
     return funcs, output
@@ -88,7 +107,55 @@ end
     
     return func
 
-def make_julia_module(name, constraint, geodesic_eq, **args):
+def to_julia_matrix(m):
+    # since always assume 4x4 matrix
+    # rewrite into Julia matrix notation
+    m = m.replace("]", ";", 3)
+    m = "[" + m.replace("[", "")
+    return m
+
+
+def make_metric_julia_function(g, name, *args):
+    # get "pretty print" string
+    s = str(g[:])
+    s = to_julia_matrix(s)
+
+    cached_funcs, cached_output = cache_functions(s)
+
+    arguments = ", ".join((str(i) for i in ['u', *args]))
+
+    func = f"""@inline function {name}({arguments})
+    let t = u[1], r = u[2], theta = u[3], phi = u[4] 
+        {cached_funcs}
+        @SMatrix {cached_output}
+    end
+end 
+    """
+    return func
+
+def make_jacobian_julia_function(jac, *args):
+    matrix_strings = [to_julia_matrix(str(v)) for (_, v) in jac.items()]
+
+    components = "\n".join(
+        [f"comp{i+1} = @SMatrix {matrix_strings[i]}" for i in range(4)]
+    )
+
+    arguments = ", ".join((str(i) for i in ['u', *args]))
+    
+    cached_funcs, cached_output = cache_functions(components)
+
+    func = f"""@inline function jacobian({arguments})
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        {cached_funcs}
+        {cached_output}
+        (comp1, comp2, comp3, comp4)
+    end
+end
+    """
+    
+    return func
+
+def make_julia_module(name, constraint, geodesic_eq, g, ginv, jac, **args):
     arg_names = list(args.keys())
     if len(arg_names) == 0:
         raise "Needs at least one argument."
@@ -99,12 +166,16 @@ def make_julia_module(name, constraint, geodesic_eq, **args):
     
     constraint_function = make_constraint_julia_function(constraint, *arg_names)
     geodesic_function = make_geodesic_julia_function(geodesic_eq, *arg_names)
+    g_function = make_metric_julia_function(g, "metric", *arg_names)
+    ginv_function = make_metric_julia_function(ginv, "inverse_metric", *arg_names)
+    jacobian_function = make_jacobian_julia_function(jac, *arg_names)
     
     content = f"""\"\"\"
 
 Automatically generated from SageMath calculations
 
 Fergus Baker - 9th Nov 2021
+             - 10th Feb 2022: updated to include Jacobian method
 
 \"\"\"
 module {name}Coords
@@ -113,6 +184,10 @@ using ..ComputedGeodesicEquations
 
 {geodesic_function}
 {constraint_function}
+{jacobian_function}
+{g_function}
+{ginv_function}
+
 end # module
 
 @with_kw struct {name}{{T}} <: AbstractMetricParams{{T}}
@@ -120,17 +195,33 @@ end # module
     {struct_fields}
 end
 
+@with_kw struct {name}Jac{{T}} <: AbstractMetricParams{{T}}
+    @deftype T
+    {struct_fields}
+end
+
 geodesic_eq(m::{name}{{T}}, u, v) where {{T}} = {name}Coords.geodesic_eq(u, v, {struct_arguments})
+geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = {name}Coords.jac_geodesic_eq(u, v, m)
+
 constrain(m::{name}{{T}}, u, v; μ::T=0.0) where {{T}} = {name}Coords.constrain(μ, u, v, {struct_arguments})
 
-export {name}Coords, {name}
+# specialisations
+metric(m::{name}{{T}}, u) where {{T}} = {name}Coords.metric(u, {struct_arguments})
+inverse_metric(m::{name}{{T}}, u) where {{T}} = {name}Coords.inverse_metric(u, {struct_arguments})
+jacobian(m::{name}{{T}}, u) where {{T}} = {name}Coords.jacobian(u, {struct_arguments})
+metric(m::{name}Jac{{T}}, u) where {{T}} = {name}Coords.metric(u, {struct_arguments})
+inverse_metric(m::{name}Jac{{T}}, u) where {{T}} = {name}Coords.inverse_metric(u, {struct_arguments})
+jacobian(m::{name}Jac{{T}}, u) where {{T}} = {name}Coords.jacobian(u, {struct_arguments})
+
+export {name}Coords, {name}, {name}Jac
     """
     
     return content
     
-def make_julia_module_from_metric_spherical(name, metric, **args):
+def make_julia_module_from_metric_spherical(name, coords, metric, **args):
     constraint, geodesic_eq = generate_geodesic_equations_spherical(metric)
-    return make_julia_module(name, constraint, geodesic_eq, **args)
+    ginv, jac = generate_jacobian_functions(metric, coords)
+    return make_julia_module(name, constraint, geodesic_eq, metric, ginv, jac, **args)
 
 def save_module(module, name):
     with open(name + ".jl", "w") as f:

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -127,7 +127,7 @@ def make_metric_julia_function(g, name, *args):
     func = f"""@inline function {name}({arguments})
     let t = u[1], r = u[2], theta = u[3], phi = u[4] 
         {cached_funcs}
-        @SMatrix {cached_output}
+        ComputedGeodesicEquations.@SMatrix {cached_output}
     end
 end 
     """
@@ -137,7 +137,7 @@ def make_jacobian_julia_function(jac, *args):
     matrix_strings = [to_julia_matrix(str(v)) for (_, v) in jac.items()]
 
     components = "\n".join(
-        [f"comp{i+1} = @SMatrix {matrix_strings[i]}" for i in range(4)]
+        [f"comp{i+1} = ComputedGeodesicEquations.@SMatrix {matrix_strings[i]}" for i in range(4)]
     )
 
     arguments = ", ".join((str(i) for i in ['u', *args]))

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -201,7 +201,7 @@ end
 end
 
 geodesic_eq(m::{name}{{T}}, u, v) where {{T}} = {name}Coords.geodesic_eq(u, v, {struct_arguments})
-geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = {name}Coords.jac_geodesic_eq(u, v, m)
+geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = jac_geodesic_eq(u, v, m)
 
 constrain(m::{name}{{T}}, u, v; μ::T=0.0) where {{T}} = {name}Coords.constrain(μ, u, v, {struct_arguments})
 

--- a/generator-src/generate.py
+++ b/generator-src/generate.py
@@ -99,18 +99,18 @@ def generate_johannsen_psaltis():
     
     Sigma = r**2 + a**2 * cos(theta)**2
     Delta = r**2 - 2*M*r + a**2
-    h = epsilon * M^2 * r / Sigma^2
+    h = epsilon * M**2 * r / Sigma**2
 
     g = KM.lorentzian_metric('g')
 
     g[0,0] = -(1+h) * (1 - (R*r)/Sigma)
-    g[1,1] = Sigma * (1 + h) / (Delta + a^2 * h * sin(theta)^2)
+    g[1,1] = Sigma * (1 + h) / (Delta + a**2 * h * sin(theta)**2)
     g[2,2] = Sigma
-    g[3,3] = sin(theta)^2 * (
-        r^2 + a^2 + (2 * M * r * a^2 * sin(theta)^2) / Sigma
-    ) + (h * (Sigma + 2 * M * r) * a^2 * sin(theta)^4 )/ Sigma
+    g[3,3] = sin(theta)**2 * (
+        r**2 + a**2 + (2 * M * r * a**2 * sin(theta)**2) / Sigma
+    ) + (h * (Sigma + 2 * M * r) * a**2 * sin(theta)**4 )/ Sigma
 
-    g[0,3] = - (1+h) * (R * r * a * sin(theta)^2) / (Sigma)
+    g[0,3] = - (1+h) * (R * r * a * sin(theta)**2) / (Sigma)
     
     module = make_julia_module_from_metric_spherical(name, (t, r, theta, phi), g, M=1.0, a=0.0, epsilon=0.0)
 
@@ -124,7 +124,7 @@ inner_radius(m::{name}Jac{{T}}) where {{T}} = m.M + √(m.M^2 - m.a^2)
 
 
 def generate_all():
-    generate_morris_thorne()
-    generate_boyer_lindquist()
-    generate_eddington_finkelstein()
+    #generate_morris_thorne()
+    #generate_boyer_lindquist()
+    #generate_eddington_finkelstein()
     generate_johannsen_psaltis()

--- a/generator-src/generate.py
+++ b/generator-src/generate.py
@@ -97,9 +97,9 @@ def generate_johannsen_psaltis():
     R = 2*M
     epsilon = var("epsilon")
     
-    h = epsilon * M^2 * r / Sigma^2
     Sigma = r**2 + a**2 * cos(theta)**2
     Delta = r**2 - 2*M*r + a**2
+    h = epsilon * M^2 * r / Sigma^2
 
     g = KM.lorentzian_metric('g')
 

--- a/generator-src/generate.py
+++ b/generator-src/generate.py
@@ -18,7 +18,7 @@ def generate_morris_thorne():
     g[2, 2] = (b**2 + r**2)
     g[3, 3] = (b**2 + r**2) * sin(theta)
 
-    module = make_julia_module_from_metric_spherical(name, g, b=1.0)
+    module = make_julia_module_from_metric_spherical(name, (t, r, theta, phi), g, b=1.0)
     
     save_module(module, "morris-thorne")
 
@@ -40,11 +40,12 @@ def generate_eddington_finkelstein():
 
     g[0, 1] = 2 * M / r
 
-    module = make_julia_module_from_metric_spherical(name, g, M=1.0)
+    module = make_julia_module_from_metric_spherical(name, (t, r, theta, phi), g, M=1.0)
 
     module += f"""
 # additional specializations
 inner_radius(m::{name}{{T}}) where {{T}} = 2 * m.M
+inner_radius(m::{name}Jac{{T}}) where {{T}} = 2 * m.M
     """
     
     save_module(module, "eddington-finkelstein")
@@ -73,20 +74,57 @@ def generate_boyer_lindquist():
 
     g[0,3] = -(R * r * a * sin(theta)**2) / Sigma
 
-    module = make_julia_module_from_metric_spherical(name, g, M=1.0, a=0.0)
+    module = make_julia_module_from_metric_spherical(name, (t, r, theta, phi), g, M=1.0, a=0.0)
 
     module += f"""
 # additional specializations
 inner_radius(m::{name}{{T}}) where {{T}} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::{name}Jac{{T}}) where {{T}} = m.M + √(m.M^2 - m.a^2)
     """
     
     save_module(module, "boyer-lindquist")
+    
+def generate_johannsen_psaltis():
+    name = "JohannsenPsaltis"
+    
+    KM = Manifold(4, 'M', latex_name=r'\mathcal{M}', start_index=0)  
+    chart = KM.chart(names=('t', 'r', 'theta', 'phi',))
+    (t, r, theta, phi,) = chart._first_ngens(4)
+
+    ## METRIC SPECIFICATION
+    a = var("a")
+    M = var("M")
+    R = 2*M
+    epsilon = var("epsilon")
+    
+    h = epsilon * M^2 * r / Sigma^2
+    Sigma = r**2 + a**2 * cos(theta)**2
+    Delta = r**2 - 2*M*r + a**2
+
+    g = KM.lorentzian_metric('g')
+
+    g[0,0] = -(1+h) * (1 - (R*r)/Sigma)
+    g[1,1] = Sigma * (1 + h) / (Delta + a^2 * h * sin(theta)^2)
+    g[2,2] = Sigma
+    g[3,3] = sin(theta)^2 * (
+        r^2 + a^2 + (2 * M * r * a^2 * sin(theta)^2) / Sigma
+    ) + (h * (Sigma + 2 * M * r) * a^2 * sin(theta)^4 )/ Sigma
+
+    g[0,3] = - (1+h) * (R * r * a * sin(theta)^2) / (Sigma)
+    
+    module = make_julia_module_from_metric_spherical(name, (t, r, theta, phi), g, M=1.0, a=0.0, epsilon=0.0)
+
+    module += f"""
+# additional specializations
+inner_radius(m::{name}{{T}}) where {{T}} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::{name}Jac{{T}}) where {{T}} = m.M + √(m.M^2 - m.a^2)
+    """
+    
+    save_module(module, "johannsen-psaltis")
 
 
 def generate_all():
+    generate_morris_thorne()
     generate_boyer_lindquist()
     generate_eddington_finkelstein()
-
-
-if __name__ == "__main__":
-    generate_all()
+    generate_johannsen_psaltis()

--- a/src/ComputedGeodesicEquations.jl
+++ b/src/ComputedGeodesicEquations.jl
@@ -2,7 +2,7 @@ module ComputedGeodesicEquations
 
 using Parameters
 using Tullio
-import StaticArrays: @SMatrix
+import StaticArrays: @SMatrix, SMatrix, MArray
 import GeodesicBase: AbstractMetricParams, geodesic_eq, constrain, on_chart, inner_radius
 
 """

--- a/src/ComputedGeodesicEquations.jl
+++ b/src/ComputedGeodesicEquations.jl
@@ -1,8 +1,9 @@
 module ComputedGeodesicEquations
 
 using Parameters
-import GeodesicBase:
-    AbstractMetricParams, geodesic_eq, constrain, on_chart, inner_radius
+using Tullio
+import StaticArrays: @SMatrix
+import GeodesicBase: AbstractMetricParams, geodesic_eq, constrain, on_chart, inner_radius
 
 """
     let_unpack(u, v, expr)
@@ -21,8 +22,8 @@ macro let_unpack(u, v, expr)
     quote
         @inbounds let t = $u[1],
             r = $u[2],
-            θ = $u[3],
-            ϕ = $u[4],
+            theta = $u[3],
+            phi = $u[4],
             v_t = $v[1],
             v_r = $v[2],
             v_theta = $v[3],
@@ -33,10 +34,35 @@ macro let_unpack(u, v, expr)
     end |> esc
 end
 
+@inline function christoffel_symbols(ginv, jac)
+    # TODO: using heap allocations by default
+    # can we somehow make this method stack allocated for 64 floats?
+    Γ = zeros(MArray{Tuple{4,4,4},Float64})
+    @tullio Γ[i, k, l] = 1 / 2 * ginv[i, m] * (jac[l][m, k] + jac[k][m, l] - jac[m][k, l])
+    Γ
+end
+
+@inline function geodesic_eq_from_christoffel(Γ, v)
+    # TODO: using heap allocations by default
+    # can we somehow make this method stack allocated for 4 floats?
+    δxδλ = zeros(MArray{Tuple{4},Float64})
+    @tullio δxδλ[i] = -Γ[i, j, k] * v[j] * v[k]
+    δxδλ
+end
+
+@inline function jac_geodesic_eq(m::AbstractMetricParams{T}, u, v) where {T}
+    ginv = inverse_metric(m, u)
+    jac = jacobian(m, u)
+    Γ = christoffel_symbols(ginv, jac)
+    geodesic_eq_from_christoffel(Γ, v)
+end
+
+
 include("boyer-lindquist.jl")
 include("eddington-finkelstein.jl")
 include("morris-thorne.jl")
+include("johannsen-psaltis.jl")
 
-export geodesic_eq, constrain, on_chart, inner_radius 
+export geodesic_eq, constrain, on_chart, inner_radius
 
 end # module

--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -367,12 +367,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp1 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         comp2 = ComputedGeodesicEquations.@SMatrix [
             2*(M*a^2*cos_theta^2-M*r^2)/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 -2*(M*a^3*cos_theta^2-M*a*r^2)*sin_theta^2/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
             0 2*(a^2*r-M*r^2+(M*a^2-a^2*r)*cos_theta^2)/(a^4-4*M*a^2*r-4*M*r^3+r^4+2*(2*M^2+a^2)*r^2) 0 0
@@ -385,12 +380,7 @@ end
             0 0 -2*a^2*cos_theta*sin_theta 0
             -4*(M*a^3*r+M*a*r^3)*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 2*((a^6-2*M*a^4*r+a^4*r^2)*cos_theta^5+2*(a^4*r^2-2*M*a^2*r^3+a^2*r^4)*cos_theta^3+(2*M*a^4*r+4*M*a^2*r^3+a^2*r^4+r^6)*cos_theta)*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
         ]
-        comp4 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp4 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         (comp1, comp2, comp3, comp4)
     end
 end
@@ -440,7 +430,7 @@ end
 
 geodesic_eq(m::BoyerLindquist{T}, u, v) where {T} =
     BoyerLindquistCoords.geodesic_eq(u, v, m.M, m.a)
-geodesic_eq(m::BoyerLindquistJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+geodesic_eq(m::BoyerLindquistJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::BoyerLindquist{T}, u, v; μ::T = 0.0) where {T} =
     BoyerLindquistCoords.constrain(μ, u, v, m.M, m.a)

--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -3,6 +3,7 @@
 Automatically generated from SageMath calculations
 
 Fergus Baker - 9th Nov 2021
+             - 10th Feb 2022: updated to include Jacobian method
 
 """
 module BoyerLindquistCoords
@@ -11,8 +12,8 @@ using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, M, a)
     ComputedGeodesicEquations.@let_unpack u v begin
-        cos_theta = cos(θ)
-        sin_theta = sin(θ)
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
 
         out1 =
             2 * (
@@ -261,8 +262,8 @@ end
 
 @inline function constrain(μ, u, v, M, a)
     ComputedGeodesicEquations.@let_unpack u v begin
-        cos_theta = cos(θ)
-        sin_theta = sin(θ)
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
 
         (
             2 * (M * a^3 * r - 2 * M^2 * a * r^2 + M * a * r^3) * v_phi * sin_theta^2 -
@@ -361,6 +362,68 @@ end
     end
 end
 
+@inline function jacobian(u, M, a)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        comp1 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        comp2 = @SMatrix [
+            2*(M*a^2*cos_theta^2-M*r^2)/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 -2*(M*a^3*cos_theta^2-M*a*r^2)*sin_theta^2/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
+            0 2*(a^2*r-M*r^2+(M*a^2-a^2*r)*cos_theta^2)/(a^4-4*M*a^2*r-4*M*r^3+r^4+2*(2*M^2+a^2)*r^2) 0 0
+            0 0 2*r 0
+            -2*(M*a^3*cos_theta^2-M*a*r^2)*sin_theta^2/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 2*((M*a^4*cos_theta^2-M*a^2*r^2)*sin_theta^4+(a^4*r*cos_theta^4+2*a^2*r^3*cos_theta^2+r^5)*sin_theta^2)/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
+        ]
+        comp3 = @SMatrix [
+            4*M*a^2*r*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 -4*(M*a^3*r+M*a*r^3)*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
+            0 -2*a^2*cos_theta*sin_theta/(a^2-2*M*r+r^2) 0 0
+            0 0 -2*a^2*cos_theta*sin_theta 0
+            -4*(M*a^3*r+M*a*r^3)*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 2*((a^6-2*M*a^4*r+a^4*r^2)*cos_theta^5+2*(a^4*r^2-2*M*a^2*r^3+a^2*r^4)*cos_theta^3+(2*M*a^4*r+4*M*a^2*r^3+a^2*r^4+r^6)*cos_theta)*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
+        ]
+        comp4 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        (comp1, comp2, comp3, comp4)
+    end
+end
+
+@inline function metric(u, M, a)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            2*M*r/(a^2*cos_theta^2+r^2)-1 0 0 -2*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2)
+            0 (a^2*cos_theta^2+r^2)/(a^2-2*M*r+r^2) 0 0
+            0 0 a^2*cos_theta^2+r^2 0
+            -2*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2) 0 0 (2*M*a^2*r*sin_theta^2/(a^2*cos_theta^2+r^2)+a^2+r^2)*sin_theta^2
+        ]
+    end
+end
+
+@inline function inverse_metric(u, M, a)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            -(2 * M * a^2 * r * sin_theta^2 + a^2 * r^2 + r^4 + (a^4 + a^2 * r^2) * cos_theta^2)/(a^2*r^2-2*M*r^3+r^4+(a^4-2*M*a^2*r+a^2*r^2)*cos_theta^2) 0 0 -2*M*a*r/(a^2*r^2-2*M*r^3+r^4+(a^4-2*M*a^2*r+a^2*r^2)*cos_theta^2)
+            0 (a^2-2*M*r+r^2)/(a^2*cos_theta^2+r^2) 0 0
+            0 0 1/(a^2*cos_theta^2+r^2) 0
+            -2*M*a*r/(a^2*r^2-2*M*r^3+r^4+(a^4-2*M*a^2*r+a^2*r^2)*cos_theta^2) 0 0 (a^2*cos_theta^2-2*M*r+r^2)/(2*M*a^2*r*sin_theta^4-(2*M*a^2*r-a^2*r^2+2*M*r^3-r^4-(a^4+a^2*r^2)*cos_theta^2)*sin_theta^2)
+        ]
+    end
+end
+
+
 end # module
 
 @with_kw struct BoyerLindquist{T} <: AbstractMetricParams{T}
@@ -369,11 +432,31 @@ end # module
     a = 0.0
 end
 
-geodesic_eq(m::BoyerLindquist, u, v) = BoyerLindquistCoords.geodesic_eq(u, v, m.M, m.a)
+@with_kw struct BoyerLindquistJac{T} <: AbstractMetricParams{T}
+    @deftype T
+    M = 1.0
+    a = 0.0
+end
+
+geodesic_eq(m::BoyerLindquist{T}, u, v) where {T} =
+    BoyerLindquistCoords.geodesic_eq(u, v, m.M, m.a)
+geodesic_eq(m::BoyerLindquistJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+
 constrain(m::BoyerLindquist{T}, u, v; μ::T = 0.0) where {T} =
     BoyerLindquistCoords.constrain(μ, u, v, m.M, m.a)
 
-export BoyerLindquistCoords, BoyerLindquist
+# specialisations
+metric(m::BoyerLindquist{T}, u) where {T} = BoyerLindquistCoords.metric(u, m.M, m.a)
+inverse_metric(m::BoyerLindquist{T}, u) where {T} =
+    BoyerLindquistCoords.inverse_metric(u, m.M, m.a)
+jacobian(m::BoyerLindquist{T}, u) where {T} = BoyerLindquistCoords.jacobian(u, m.M, m.a)
+metric(m::BoyerLindquistJac{T}, u) where {T} = BoyerLindquistCoords.metric(u, m.M, m.a)
+inverse_metric(m::BoyerLindquistJac{T}, u) where {T} =
+    BoyerLindquistCoords.inverse_metric(u, m.M, m.a)
+jacobian(m::BoyerLindquistJac{T}, u) where {T} = BoyerLindquistCoords.jacobian(u, m.M, m.a)
+
+export BoyerLindquistCoords, BoyerLindquist, BoyerLindquistJac
 
 # additional specializations
 inner_radius(m::BoyerLindquist{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::BoyerLindquistJac{T}) where {T} = m.M + √(m.M^2 - m.a^2)

--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -367,25 +367,25 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = @SMatrix [
+        comp1 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 0
         ]
-        comp2 = @SMatrix [
+        comp2 = ComputedGeodesicEquations.@SMatrix [
             2*(M*a^2*cos_theta^2-M*r^2)/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 -2*(M*a^3*cos_theta^2-M*a*r^2)*sin_theta^2/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
             0 2*(a^2*r-M*r^2+(M*a^2-a^2*r)*cos_theta^2)/(a^4-4*M*a^2*r-4*M*r^3+r^4+2*(2*M^2+a^2)*r^2) 0 0
             0 0 2*r 0
             -2*(M*a^3*cos_theta^2-M*a*r^2)*sin_theta^2/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 2*((M*a^4*cos_theta^2-M*a^2*r^2)*sin_theta^4+(a^4*r*cos_theta^4+2*a^2*r^3*cos_theta^2+r^5)*sin_theta^2)/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
         ]
-        comp3 = @SMatrix [
+        comp3 = ComputedGeodesicEquations.@SMatrix [
             4*M*a^2*r*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 -4*(M*a^3*r+M*a*r^3)*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
             0 -2*a^2*cos_theta*sin_theta/(a^2-2*M*r+r^2) 0 0
             0 0 -2*a^2*cos_theta*sin_theta 0
             -4*(M*a^3*r+M*a*r^3)*cos_theta*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4) 0 0 2*((a^6-2*M*a^4*r+a^4*r^2)*cos_theta^5+2*(a^4*r^2-2*M*a^2*r^3+a^2*r^4)*cos_theta^3+(2*M*a^4*r+4*M*a^2*r^3+a^2*r^4+r^6)*cos_theta)*sin_theta/(a^4*cos_theta^4+2*a^2*r^2*cos_theta^2+r^4)
         ]
-        comp4 = @SMatrix [
+        comp4 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
@@ -400,7 +400,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             2*M*r/(a^2*cos_theta^2+r^2)-1 0 0 -2*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2)
             0 (a^2*cos_theta^2+r^2)/(a^2-2*M*r+r^2) 0 0
             0 0 a^2*cos_theta^2+r^2 0
@@ -414,7 +414,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             -(2 * M * a^2 * r * sin_theta^2 + a^2 * r^2 + r^4 + (a^4 + a^2 * r^2) * cos_theta^2)/(a^2*r^2-2*M*r^3+r^4+(a^4-2*M*a^2*r+a^2*r^2)*cos_theta^2) 0 0 -2*M*a*r/(a^2*r^2-2*M*r^3+r^4+(a^4-2*M*a^2*r+a^2*r^2)*cos_theta^2)
             0 (a^2-2*M*r+r^2)/(a^2*cos_theta^2+r^2) 0 0
             0 0 1/(a^2*cos_theta^2+r^2) 0

--- a/src/eddington-finkelstein.jl
+++ b/src/eddington-finkelstein.jl
@@ -54,12 +54,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp1 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         comp2 = ComputedGeodesicEquations.@SMatrix [
             -2*M/r^2 -2*M/r^2 0 0
             -2*M/r^2 -2*M/r^2 0 0
@@ -72,12 +67,7 @@ end
             0 0 0 0
             0 0 0 2*r^2*cos_theta*sin_theta
         ]
-        comp4 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp4 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         (comp1, comp2, comp3, comp4)
     end
 end
@@ -125,7 +115,7 @@ end
 
 geodesic_eq(m::EddingtonFinkelstein{T}, u, v) where {T} =
     EddingtonFinkelsteinCoords.geodesic_eq(u, v, m.M)
-geodesic_eq(m::EddingtonFinkelsteinJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+geodesic_eq(m::EddingtonFinkelsteinJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::EddingtonFinkelstein{T}, u, v; μ::T = 0.0) where {T} =
     EddingtonFinkelsteinCoords.constrain(μ, u, v, m.M)

--- a/src/eddington-finkelstein.jl
+++ b/src/eddington-finkelstein.jl
@@ -54,25 +54,25 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = @SMatrix [
+        comp1 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 0
         ]
-        comp2 = @SMatrix [
+        comp2 = ComputedGeodesicEquations.@SMatrix [
             -2*M/r^2 -2*M/r^2 0 0
             -2*M/r^2 -2*M/r^2 0 0
             0 0 2*r 0
             0 0 0 2*r*sin_theta^2
         ]
-        comp3 = @SMatrix [
+        comp3 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 2*r^2*cos_theta*sin_theta
         ]
-        comp4 = @SMatrix [
+        comp4 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
@@ -87,7 +87,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             2*M/r-1 2*M/r 0 0
             2*M/r 2*M/r+1 0 0
             0 0 r^2 0
@@ -101,7 +101,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             -(2 * M + r)/r 2*M/r 0 0
             2*M/r -(2 * M - r)/r 0 0
             0 0 r^(-2) 0

--- a/src/johannsen-psaltis.jl
+++ b/src/johannsen-psaltis.jl
@@ -3136,12 +3136,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp1 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         comp2 = ComputedGeodesicEquations.@SMatrix [
             (2*M*a^6*cos_theta^6-8*M^3*epsilon*r^3+3*M^2*epsilon*r^4-2*M*r^6-(M^2*a^4*epsilon-2*M*a^4*r^2)*cos_theta^4+2*(2*M^3*a^2*epsilon*r+M^2*a^2*epsilon*r^2-M*a^2*r^4)*cos_theta^2)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 -2*(M*a^7*cos_theta^6+M*a^5*r^2*cos_theta^4-4*M^3*a*epsilon*r^3-M*a*r^6+(2*M^3*a^3*epsilon*r-M*a^3*r^4)*cos_theta^2)*sin_theta^2/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
             0 (2*M^4*a^2*epsilon^2*r^3+4*M^2*a^2*epsilon*r^6+4*M^3*epsilon*r^7-3*M^2*epsilon*r^8+2*a^2*r^9-2*M*r^10+2*(M*a^10-a^10*r)*cos_theta^10+(M^2*a^8*epsilon+2*a^10*r+6*M*a^8*r^2-8*a^8*r^3)*cos_theta^8-4*(M^2*a^6*epsilon*r^2-2*a^8*r^3-M*a^6*r^4+3*a^6*r^5)*cos_theta^6+2*(2*M^2*a^6*epsilon*r^2+2*M^3*a^4*epsilon*r^3-7*M^2*a^4*epsilon*r^4+6*a^6*r^5-2*M*a^4*r^6-4*a^4*r^7)*cos_theta^4-2*(M^4*a^2*epsilon^2*r^3-4*M^2*a^4*epsilon*r^4-4*M^3*a^2*epsilon*r^5+6*M^2*a^2*epsilon*r^6-4*a^4*r^7+3*M*a^2*r^8+a^2*r^9)*cos_theta^2)/(M^4*a^4*epsilon^2*r^2*sin_theta^4+a^4*r^8-4*M*a^2*r^9-4*M*r^11+r^12+2*(2*M^2+a^2)*r^10+(a^12-4*M*a^10*r-4*M*a^8*r^3+a^8*r^4+2*(2*M^2*a^8+a^10)*r^2)*cos_theta^8+4*(a^10*r^2-4*M*a^8*r^3-4*M*a^6*r^5+a^6*r^6+2*(2*M^2*a^6+a^8)*r^4)*cos_theta^6+6*(a^8*r^4-4*M*a^6*r^5-4*M*a^4*r^7+a^4*r^8+2*(2*M^2*a^4+a^6)*r^6)*cos_theta^4+4*(a^6*r^6-4*M*a^4*r^7-4*M*a^2*r^9+a^2*r^10+2*(2*M^2*a^2+a^4)*r^8)*cos_theta^2+2*(M^2*a^4*epsilon*r^5-2*M^3*a^2*epsilon*r^6+M^2*a^2*epsilon*r^7+(M^2*a^8*epsilon*r-2*M^3*a^6*epsilon*r^2+M^2*a^6*epsilon*r^3)*cos_theta^4+2*(M^2*a^6*epsilon*r^3-2*M^3*a^4*epsilon*r^4+M^2*a^4*epsilon*r^5)*cos_theta^2)*sin_theta^2) 0 0
@@ -3154,12 +3149,7 @@ end
             0 0 -2*a^2*cos_theta*sin_theta 0
             -4*((M*a^7*r+M*a^5*r^3)*cos_theta^5-2*(M^3*a^3*epsilon*r^2-M*a^5*r^3-M*a^3*r^5)*cos_theta^3+(3*M^3*a^3*epsilon*r^2+M^3*a*epsilon*r^4+M*a^3*r^5+M*a*r^7)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 2*(2*(M*a^8*r*cos_theta^5+(M^2*a^6*epsilon*r+2*M*a^6*r^3)*cos_theta^3+(3*M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+M*a^4*r^5)*cos_theta)*sin_theta^5+2*(2*M*a^8*r*cos_theta^7+(M^2*a^6*epsilon*r+6*M*a^6*r^3)*cos_theta^5+2*(M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+3*M*a^4*r^5)*cos_theta^3+(2*M^3*a^2*epsilon*r^4+M^2*a^2*epsilon*r^5+2*M*a^2*r^7)*cos_theta)*sin_theta^3+((a^10+a^8*r^2)*cos_theta^9+4*(a^8*r^2+a^6*r^4)*cos_theta^7+6*(a^6*r^4+a^4*r^6)*cos_theta^5+4*(a^4*r^6+a^2*r^8)*cos_theta^3+(a^2*r^8+r^10)*cos_theta)*sin_theta)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
         ]
-        comp4 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp4 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         (comp1, comp2, comp3, comp4)
     end
 end
@@ -3211,7 +3201,7 @@ end
 
 geodesic_eq(m::JohannsenPsaltis{T}, u, v) where {T} =
     JohannsenPsaltisCoords.geodesic_eq(u, v, m.M, m.a, m.epsilon)
-geodesic_eq(m::JohannsenPsaltisJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+geodesic_eq(m::JohannsenPsaltisJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::JohannsenPsaltis{T}, u, v; μ::T = 0.0) where {T} =
     JohannsenPsaltisCoords.constrain(μ, u, v, m.M, m.a, m.epsilon)

--- a/src/johannsen-psaltis.jl
+++ b/src/johannsen-psaltis.jl
@@ -3136,25 +3136,25 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = @SMatrix [
+        comp1 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 0
         ]
-        comp2 = @SMatrix [
+        comp2 = ComputedGeodesicEquations.@SMatrix [
             (2*M*a^6*cos_theta^6-8*M^3*epsilon*r^3+3*M^2*epsilon*r^4-2*M*r^6-(M^2*a^4*epsilon-2*M*a^4*r^2)*cos_theta^4+2*(2*M^3*a^2*epsilon*r+M^2*a^2*epsilon*r^2-M*a^2*r^4)*cos_theta^2)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 -2*(M*a^7*cos_theta^6+M*a^5*r^2*cos_theta^4-4*M^3*a*epsilon*r^3-M*a*r^6+(2*M^3*a^3*epsilon*r-M*a^3*r^4)*cos_theta^2)*sin_theta^2/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
             0 (2*M^4*a^2*epsilon^2*r^3+4*M^2*a^2*epsilon*r^6+4*M^3*epsilon*r^7-3*M^2*epsilon*r^8+2*a^2*r^9-2*M*r^10+2*(M*a^10-a^10*r)*cos_theta^10+(M^2*a^8*epsilon+2*a^10*r+6*M*a^8*r^2-8*a^8*r^3)*cos_theta^8-4*(M^2*a^6*epsilon*r^2-2*a^8*r^3-M*a^6*r^4+3*a^6*r^5)*cos_theta^6+2*(2*M^2*a^6*epsilon*r^2+2*M^3*a^4*epsilon*r^3-7*M^2*a^4*epsilon*r^4+6*a^6*r^5-2*M*a^4*r^6-4*a^4*r^7)*cos_theta^4-2*(M^4*a^2*epsilon^2*r^3-4*M^2*a^4*epsilon*r^4-4*M^3*a^2*epsilon*r^5+6*M^2*a^2*epsilon*r^6-4*a^4*r^7+3*M*a^2*r^8+a^2*r^9)*cos_theta^2)/(M^4*a^4*epsilon^2*r^2*sin_theta^4+a^4*r^8-4*M*a^2*r^9-4*M*r^11+r^12+2*(2*M^2+a^2)*r^10+(a^12-4*M*a^10*r-4*M*a^8*r^3+a^8*r^4+2*(2*M^2*a^8+a^10)*r^2)*cos_theta^8+4*(a^10*r^2-4*M*a^8*r^3-4*M*a^6*r^5+a^6*r^6+2*(2*M^2*a^6+a^8)*r^4)*cos_theta^6+6*(a^8*r^4-4*M*a^6*r^5-4*M*a^4*r^7+a^4*r^8+2*(2*M^2*a^4+a^6)*r^6)*cos_theta^4+4*(a^6*r^6-4*M*a^4*r^7-4*M*a^2*r^9+a^2*r^10+2*(2*M^2*a^2+a^4)*r^8)*cos_theta^2+2*(M^2*a^4*epsilon*r^5-2*M^3*a^2*epsilon*r^6+M^2*a^2*epsilon*r^7+(M^2*a^8*epsilon*r-2*M^3*a^6*epsilon*r^2+M^2*a^6*epsilon*r^3)*cos_theta^4+2*(M^2*a^6*epsilon*r^3-2*M^3*a^4*epsilon*r^4+M^2*a^4*epsilon*r^5)*cos_theta^2)*sin_theta^2) 0 0
             0 0 2*r 0
             -2*(M*a^7*cos_theta^6+M*a^5*r^2*cos_theta^4-4*M^3*a*epsilon*r^3-M*a*r^6+(2*M^3*a^3*epsilon*r-M*a^3*r^4)*cos_theta^2)*sin_theta^2/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 ((2*M*a^8*cos_theta^6-8*M^3*a^2*epsilon*r^3-3*M^2*a^2*epsilon*r^4-2*M*a^2*r^6+(M^2*a^6*epsilon+2*M*a^6*r^2)*cos_theta^4+2*(2*M^3*a^4*epsilon*r-M^2*a^4*epsilon*r^2-M*a^4*r^4)*cos_theta^2)*sin_theta^4+2*(a^8*r*cos_theta^8+4*a^6*r^3*cos_theta^6+6*a^4*r^5*cos_theta^4+4*a^2*r^7*cos_theta^2+r^9)*sin_theta^2)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
         ]
-        comp3 = @SMatrix [
+        comp3 = ComputedGeodesicEquations.@SMatrix [
             4*(M*a^6*r*cos_theta^5-(M^2*a^4*epsilon*r-2*M*a^4*r^3)*cos_theta^3+(3*M^3*a^2*epsilon*r^2-M^2*a^2*epsilon*r^3+M*a^2*r^5)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 -4*((M*a^7*r+M*a^5*r^3)*cos_theta^5-2*(M^3*a^3*epsilon*r^2-M*a^5*r^3-M*a^3*r^5)*cos_theta^3+(3*M^3*a^3*epsilon*r^2+M^3*a*epsilon*r^4+M*a^3*r^5+M*a*r^7)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
             0 -2*((a^12-2*M*a^10*r+a^10*r^2)*cos_theta^9-2*(M^2*a^8*epsilon*r-2*a^10*r^2+4*M*a^8*r^3-2*a^8*r^4)*cos_theta^7+2*(M^2*a^8*epsilon*r+M^3*a^6*epsilon*r^2-2*M^2*a^6*epsilon*r^3+3*a^8*r^4-6*M*a^6*r^5+3*a^6*r^6)*cos_theta^5+2*(2*M^2*a^6*epsilon*r^3+2*M^3*a^4*epsilon*r^4-M^2*a^4*epsilon*r^5+2*a^6*r^6-4*M*a^4*r^7+2*a^4*r^8)*cos_theta^3+(M^4*a^4*epsilon^2*r^2+M^4*a^2*epsilon^2*r^4+2*M^2*a^4*epsilon*r^5+2*M^3*a^2*epsilon*r^6+a^4*r^8-2*M*a^2*r^9+a^2*r^10)*cos_theta)*sin_theta/(M^4*a^4*epsilon^2*r^2*sin_theta^4+a^4*r^8-4*M*a^2*r^9-4*M*r^11+r^12+2*(2*M^2+a^2)*r^10+(a^12-4*M*a^10*r-4*M*a^8*r^3+a^8*r^4+2*(2*M^2*a^8+a^10)*r^2)*cos_theta^8+4*(a^10*r^2-4*M*a^8*r^3-4*M*a^6*r^5+a^6*r^6+2*(2*M^2*a^6+a^8)*r^4)*cos_theta^6+6*(a^8*r^4-4*M*a^6*r^5-4*M*a^4*r^7+a^4*r^8+2*(2*M^2*a^4+a^6)*r^6)*cos_theta^4+4*(a^6*r^6-4*M*a^4*r^7-4*M*a^2*r^9+a^2*r^10+2*(2*M^2*a^2+a^4)*r^8)*cos_theta^2+2*(M^2*a^4*epsilon*r^5-2*M^3*a^2*epsilon*r^6+M^2*a^2*epsilon*r^7+(M^2*a^8*epsilon*r-2*M^3*a^6*epsilon*r^2+M^2*a^6*epsilon*r^3)*cos_theta^4+2*(M^2*a^6*epsilon*r^3-2*M^3*a^4*epsilon*r^4+M^2*a^4*epsilon*r^5)*cos_theta^2)*sin_theta^2) 0 0
             0 0 -2*a^2*cos_theta*sin_theta 0
             -4*((M*a^7*r+M*a^5*r^3)*cos_theta^5-2*(M^3*a^3*epsilon*r^2-M*a^5*r^3-M*a^3*r^5)*cos_theta^3+(3*M^3*a^3*epsilon*r^2+M^3*a*epsilon*r^4+M*a^3*r^5+M*a*r^7)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 2*(2*(M*a^8*r*cos_theta^5+(M^2*a^6*epsilon*r+2*M*a^6*r^3)*cos_theta^3+(3*M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+M*a^4*r^5)*cos_theta)*sin_theta^5+2*(2*M*a^8*r*cos_theta^7+(M^2*a^6*epsilon*r+6*M*a^6*r^3)*cos_theta^5+2*(M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+3*M*a^4*r^5)*cos_theta^3+(2*M^3*a^2*epsilon*r^4+M^2*a^2*epsilon*r^5+2*M*a^2*r^7)*cos_theta)*sin_theta^3+((a^10+a^8*r^2)*cos_theta^9+4*(a^8*r^2+a^6*r^4)*cos_theta^7+6*(a^6*r^4+a^4*r^6)*cos_theta^5+4*(a^4*r^6+a^2*r^8)*cos_theta^3+(a^2*r^8+r^10)*cos_theta)*sin_theta)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
         ]
-        comp4 = @SMatrix [
+        comp4 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
@@ -3169,7 +3169,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             (M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)*(2*M*r/(a^2*cos_theta^2+r^2)-1) 0 0 -2*(M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2)
             0 (a^2*cos_theta^2+r^2)*(M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)/(M^2*a^2*epsilon*r*sin_theta^2/(a^2*cos_theta^2+r^2)^2+a^2-2*M*r+r^2) 0 0
             0 0 a^2*cos_theta^2+r^2 0
@@ -3183,7 +3183,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             -(a^2 * r^8 + r^10 + (a^10 + a^8 * r^2) * cos_theta^8 + 4 * (a^8 * r^2 + a^6 * r^4) * cos_theta^6 + 6 * (a^6 * r^4 + a^4 * r^6) * cos_theta^4 + 4 * (a^4 * r^6 + a^2 * r^8) * cos_theta^2 + (2 * M * a^8 * r * cos_theta^6 + 2 * M^3 * a^2 * epsilon * r^4 + M^2 * a^2 * epsilon * r^5 + 2 * M * a^2 * r^7 + (M^2 * a^6 * epsilon * r + 6 * M * a^6 * r^3) * cos_theta^4 + 2 * (M^3 * a^4 * epsilon * r^2 + M^2 * a^4 * epsilon * r^3 + 3 * M * a^4 * r^5) * cos_theta^2) * sin_theta^2)/(M^4*a^2*epsilon^2*r^2+2*M^2*a^2*epsilon*r^5-2*M^3*epsilon*r^6+M^2*epsilon*r^7+a^2*r^8-2*M*r^9+r^10+(a^10-2*M*a^8*r+a^8*r^2)*cos_theta^8-(M^2*a^6*epsilon*r-4*a^8*r^2+8*M*a^6*r^3-4*a^6*r^4)*cos_theta^6+(2*M^2*a^6*epsilon*r-2*M^3*a^4*epsilon*r^2-M^2*a^4*epsilon*r^3+6*a^6*r^4-12*M*a^4*r^5+6*a^4*r^6)*cos_theta^4-(M^4*a^2*epsilon^2*r^2-4*M^2*a^4*epsilon*r^3+4*M^3*a^2*epsilon*r^4-M^2*a^2*epsilon*r^5-4*a^4*r^6+8*M*a^2*r^7-4*a^2*r^8)*cos_theta^2) 0 0 -2*(M*a^3*r*cos_theta^2+M*a*r^3)/(M^2*a^2*epsilon*r+a^2*r^4-2*M*r^5+r^6+(a^6-2*M*a^4*r+a^4*r^2)*cos_theta^4-(M^2*a^2*epsilon*r-2*a^4*r^2+4*M*a^2*r^3-2*a^2*r^4)*cos_theta^2)
             0 (M^2*a^2*epsilon*r*sin_theta^2+a^2*r^4-2*M*r^5+r^6+(a^6-2*M*a^4*r+a^4*r^2)*cos_theta^4+2*(a^4*r^2-2*M*a^2*r^3+a^2*r^4)*cos_theta^2)/(a^6*cos_theta^6+3*a^4*r^2*cos_theta^4+M^2*epsilon*r^3+r^6+(M^2*a^2*epsilon*r+3*a^2*r^4)*cos_theta^2) 0 0
             0 0 1/(a^2*cos_theta^2+r^2) 0

--- a/src/johannsen-psaltis.jl
+++ b/src/johannsen-psaltis.jl
@@ -1,0 +1,3237 @@
+
+"""
+
+Automatically generated from SageMath calculations
+
+Fergus Baker - 9th Nov 2021
+             - 10th Feb 2022: updated to include Jacobian method
+
+"""
+module JohannsenPsaltisCoords
+
+using ..ComputedGeodesicEquations
+
+@inline function geodesic_eq(u, v, M, a, epsilon)
+    ComputedGeodesicEquations.@let_unpack u v begin
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        out1 =
+            -(
+                2 *
+                (
+                    (
+                        2 * M^3 * a^7 * epsilon * r^3 * cos_theta^4 -
+                        M^5 * a^3 * epsilon^2 * r^4 +
+                        2 * M^3 * a^3 * epsilon * r^7 +
+                        (M^5 * a^5 * epsilon^2 * r^2 + 4 * M^3 * a^5 * epsilon * r^5) *
+                        cos_theta^2
+                    ) * sin_theta^4 -
+                    (
+                        4 * M^3 * a^3 * epsilon * r^7 +
+                        6 * M^3 * a * epsilon * r^9 +
+                        M * a^3 * r^10 +
+                        3 * M * a * r^12 - (M * a^13 - M * a^11 * r^2) * cos_theta^10 -
+                        (3 * M * a^11 * r^2 - 7 * M * a^9 * r^4) * cos_theta^8 -
+                        2 *
+                        (M^3 * a^9 * epsilon * r + M * a^9 * r^4 - 9 * M * a^7 * r^6) *
+                        cos_theta^6 +
+                        2 *
+                        (
+                            3 * M^3 * a^5 * epsilon * r^5 +
+                            M * a^7 * r^6 +
+                            11 * M * a^5 * r^8
+                        ) *
+                        cos_theta^4 +
+                        (
+                            6 * M^3 * a^5 * epsilon * r^5 +
+                            12 * M^3 * a^3 * epsilon * r^7 +
+                            3 * M * a^5 * r^8 +
+                            13 * M * a^3 * r^10
+                        ) * cos_theta^2
+                    ) * sin_theta^2
+                ) *
+                v_phi *
+                v_r +
+                (
+                    8 * M^3 * a^2 * epsilon * r^7 - 3 * M^2 * a^2 * epsilon * r^8 +
+                    8 * M^3 * epsilon * r^9 +
+                    2 * M * r^12 +
+                    (2 * M * a^2 - 3 * M^2 * epsilon) * r^10 -
+                    2 * (M * a^12 + M * a^10 * r^2) * cos_theta^10 +
+                    (
+                        M^2 * a^10 * epsilon - 6 * M * a^8 * r^4 -
+                        (6 * M * a^10 - M^2 * a^8 * epsilon) * r^2
+                    ) * cos_theta^8 -
+                    4 *
+                    (
+                        M^3 * a^8 * epsilon * r +
+                        M^3 * a^6 * epsilon * r^3 +
+                        M * a^8 * r^4 +
+                        M * a^6 * r^6
+                    ) *
+                    cos_theta^6 -
+                    2 *
+                    (
+                        3 * M^2 * a^6 * epsilon * r^4 - 2 * M * a^4 * r^8 -
+                        (2 * M * a^6 - 3 * M^2 * a^4 * epsilon) * r^6
+                    ) *
+                    cos_theta^4 +
+                    2 *
+                    (
+                        6 * M^3 * a^4 * epsilon * r^5 - 4 * M^2 * a^4 * epsilon * r^6 +
+                        6 * M^3 * a^2 * epsilon * r^7 +
+                        3 * M * a^2 * r^10 +
+                        (3 * M * a^4 - 4 * M^2 * a^2 * epsilon) * r^8
+                    ) *
+                    cos_theta^2 +
+                    (
+                        2 * M^5 * a^2 * epsilon^2 * r^4 - 3 * M^4 * a^2 * epsilon^2 * r^5 -
+                        4 * M^3 * a^2 * epsilon * r^7 +
+                        (M^4 * a^6 * epsilon^2 * r - 4 * M^3 * a^6 * epsilon * r^3) *
+                        cos_theta^4 -
+                        2 *
+                        (
+                            M^5 * a^4 * epsilon^2 * r^2 +
+                            M^4 * a^4 * epsilon^2 * r^3 +
+                            4 * M^3 * a^4 * epsilon * r^5
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^2
+                ) *
+                v_r *
+                v_t -
+                4 *
+                (
+                    (
+                        (M * a^13 * r - 2 * M^2 * a^11 * r^2 + M * a^11 * r^3) *
+                        cos_theta^11 -
+                        (
+                            M * a^13 * r - 2 * M^2 * a^11 * r^2 - 3 * M * a^11 * r^3 +
+                            8 * M^2 * a^9 * r^4 - 4 * M * a^9 * r^5
+                        ) * cos_theta^9 +
+                        2 *
+                        (
+                            M^3 * a^9 * epsilon * r^2 + M * a^9 * r^5 -
+                            6 * M^2 * a^7 * r^6 +
+                            3 * M * a^7 * r^7 +
+                            (4 * M^2 * a^9 + M^3 * a^7 * epsilon) * r^4 -
+                            2 * (M * a^11 + M^4 * a^7 * epsilon) * r^3
+                        ) *
+                        cos_theta^7 -
+                        2 *
+                        (
+                            M^3 * a^9 * epsilon * r^2 - M^3 * a^7 * epsilon * r^4 +
+                            M * a^7 * r^7 +
+                            4 * M^2 * a^5 * r^8 - 2 * M * a^5 * r^9 -
+                            2 * (3 * M^2 * a^7 + M^3 * a^5 * epsilon) * r^6 +
+                            (3 * M * a^9 + 4 * M^4 * a^5 * epsilon) * r^5 -
+                            (2 * M^4 * a^7 * epsilon - M^5 * a^5 * epsilon^2) * r^3
+                        ) *
+                        cos_theta^5 +
+                        (
+                            3 * M^5 * a^5 * epsilon^2 * r^3 -
+                            2 * M^3 * a^5 * epsilon * r^6 - 3 * M * a^5 * r^9 -
+                            2 * M^2 * a^3 * r^10 +
+                            M * a^3 * r^11 +
+                            2 * (4 * M^2 * a^5 + M^3 * a^3 * epsilon) * r^8 -
+                            4 * (M * a^7 + M^4 * a^3 * epsilon) * r^7 +
+                            (8 * M^4 * a^5 * epsilon - M^5 * a^3 * epsilon^2) * r^5 -
+                            2 * (2 * M^3 * a^7 * epsilon + M^6 * a^3 * epsilon^2) * r^4
+                        ) * cos_theta^3 -
+                        (
+                            M^5 * a^5 * epsilon^2 * r^3 - 2 * M^6 * a^3 * epsilon^2 * r^4 -
+                            M^5 * a^3 * epsilon^2 * r^5 + 2 * M^3 * a^5 * epsilon * r^6 -
+                            4 * M^4 * a^3 * epsilon * r^7 +
+                            2 * M^3 * a^3 * epsilon * r^8 +
+                            M * a^5 * r^9 - 2 * M^2 * a^3 * r^10 + M * a^3 * r^11
+                        ) * cos_theta
+                    ) *
+                    v_phi *
+                    sin_theta +
+                    (
+                        (M * a^12 * r - 2 * M^2 * a^10 * r^2 + M * a^10 * r^3) *
+                        cos_theta^9 -
+                        (
+                            M^2 * a^10 * epsilon * r - M^3 * a^8 * epsilon * r^2 +
+                            8 * M^2 * a^8 * r^4 - 4 * M * a^8 * r^5 -
+                            (4 * M * a^10 - M^2 * a^8 * epsilon) * r^3
+                        ) * cos_theta^7 +
+                        (
+                            5 * M^3 * a^6 * epsilon * r^4 - 12 * M^2 * a^6 * r^6 +
+                            6 * M * a^6 * r^7 +
+                            3 * (2 * M * a^8 - M^2 * a^6 * epsilon) * r^5 -
+                            (4 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon * r^3 +
+                            (2 * M^3 * a^8 * epsilon + M^4 * a^6 * epsilon^2) * r^2
+                        ) * cos_theta^5 -
+                        (
+                            M^4 * a^6 * epsilon^2 * r^2 + M^5 * a^4 * epsilon^2 * r^3 -
+                            7 * M^3 * a^4 * epsilon * r^6 + 8 * M^2 * a^4 * r^8 -
+                            4 * M * a^4 * r^9 -
+                            (4 * M * a^6 - 3 * M^2 * a^4 * epsilon) * r^7 +
+                            (8 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon * r^5 -
+                            (4 * M^3 * a^6 * epsilon + M^4 * a^4 * epsilon^2) * r^4
+                        ) * cos_theta^3 +
+                        (
+                            M^5 * a^4 * epsilon^2 * r^3 +
+                            2 * M^3 * a^4 * epsilon * r^6 +
+                            3 * M^3 * a^2 * epsilon * r^8 - 2 * M^2 * a^2 * r^10 +
+                            M * a^2 * r^11 +
+                            (M * a^4 - M^2 * a^2 * epsilon) * r^9 -
+                            (4 * M^4 * a^2 + M^2 * a^4) * epsilon * r^7 -
+                            (2 * M^6 * a^2 + M^4 * a^4) * epsilon^2 * r^4
+                        ) * cos_theta
+                    ) *
+                    v_t *
+                    sin_theta
+                ) *
+                v_theta
+            ) / (
+                M^4 * a^2 * epsilon^2 * r^6 + 2 * M^2 * a^2 * epsilon * r^9 -
+                2 * M^3 * epsilon * r^10 +
+                M^2 * epsilon * r^11 +
+                a^2 * r^12 - 2 * M * r^13 +
+                r^14 +
+                (a^14 - 2 * M * a^12 * r + a^12 * r^2) * cos_theta^12 -
+                (
+                    M^2 * a^10 * epsilon * r - 6 * a^12 * r^2 + 12 * M * a^10 * r^3 -
+                    6 * a^10 * r^4
+                ) * cos_theta^10 +
+                (
+                    2 * M^2 * a^10 * epsilon * r - 2 * M^3 * a^8 * epsilon * r^2 -
+                    3 * M^2 * a^8 * epsilon * r^3 + 15 * a^10 * r^4 - 30 * M * a^8 * r^5 +
+                    15 * a^8 * r^6
+                ) * cos_theta^8 -
+                (
+                    M^4 * a^6 * epsilon^2 * r^2 - 8 * M^2 * a^8 * epsilon * r^3 +
+                    8 * M^3 * a^6 * epsilon * r^4 +
+                    2 * M^2 * a^6 * epsilon * r^5 - 20 * a^8 * r^6 + 40 * M * a^6 * r^7 -
+                    20 * a^6 * r^8
+                ) * cos_theta^6 +
+                (
+                    M^4 * a^6 * epsilon^2 * r^2 - 2 * M^4 * a^4 * epsilon^2 * r^4 +
+                    12 * M^2 * a^6 * epsilon * r^5 - 12 * M^3 * a^4 * epsilon * r^6 +
+                    2 * M^2 * a^4 * epsilon * r^7 +
+                    15 * a^6 * r^8 - 30 * M * a^4 * r^9 + 15 * a^4 * r^10
+                ) * cos_theta^4 +
+                (
+                    2 * M^4 * a^4 * epsilon^2 * r^4 - M^4 * a^2 * epsilon^2 * r^6 +
+                    8 * M^2 * a^4 * epsilon * r^7 - 8 * M^3 * a^2 * epsilon * r^8 +
+                    3 * M^2 * a^2 * epsilon * r^9 +
+                    6 * a^4 * r^10 - 12 * M * a^2 * r^11 + 6 * a^2 * r^12
+                ) * cos_theta^2
+            )
+        out2 =
+            1 / 2 * (
+                4 *
+                (
+                    (a^20 - 2 * M * a^18 * r + a^18 * r^2) * cos_theta^17 -
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r - 4 * a^18 * r^2 + 8 * M * a^16 * r^3 -
+                        4 * a^16 * r^4
+                    ) *
+                    cos_theta^15 +
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r + M^3 * a^14 * epsilon * r^2 -
+                        6 * M^2 * a^14 * epsilon * r^3 + 14 * a^16 * r^4 -
+                        28 * M * a^14 * r^5 + 14 * a^14 * r^6
+                    ) *
+                    cos_theta^13 +
+                    2 *
+                    (
+                        6 * M^2 * a^14 * epsilon * r^3 + 6 * M^3 * a^12 * epsilon * r^4 -
+                        15 * M^2 * a^12 * epsilon * r^5 + 28 * a^14 * r^6 -
+                        56 * M * a^12 * r^7 + 28 * a^12 * r^8
+                    ) *
+                    cos_theta^11 +
+                    (
+                        M^4 * a^12 * epsilon^2 * r^2 +
+                        M^4 * a^10 * epsilon^2 * r^4 +
+                        30 * M^2 * a^12 * epsilon * r^5 +
+                        30 * M^3 * a^10 * epsilon * r^6 - 40 * M^2 * a^10 * epsilon * r^7 +
+                        70 * a^12 * r^8 - 140 * M * a^10 * r^9 + 70 * a^10 * r^10
+                    ) * cos_theta^9 +
+                    2 *
+                    (
+                        2 * M^4 * a^10 * epsilon^2 * r^4 +
+                        2 * M^4 * a^8 * epsilon^2 * r^6 +
+                        20 * M^2 * a^10 * epsilon * r^7 +
+                        20 * M^3 * a^8 * epsilon * r^8 - 15 * M^2 * a^8 * epsilon * r^9 +
+                        28 * a^10 * r^10 - 56 * M * a^8 * r^11 + 28 * a^8 * r^12
+                    ) *
+                    cos_theta^7 +
+                    2 *
+                    (
+                        3 * M^4 * a^8 * epsilon^2 * r^6 +
+                        3 * M^4 * a^6 * epsilon^2 * r^8 +
+                        15 * M^2 * a^8 * epsilon * r^9 +
+                        15 * M^3 * a^6 * epsilon * r^10 - 6 * M^2 * a^6 * epsilon * r^11 +
+                        14 * a^8 * r^12 - 28 * M * a^6 * r^13 + 14 * a^6 * r^14
+                    ) *
+                    cos_theta^5 +
+                    2 *
+                    (
+                        2 * M^4 * a^6 * epsilon^2 * r^8 +
+                        2 * M^4 * a^4 * epsilon^2 * r^10 +
+                        6 * M^2 * a^6 * epsilon * r^11 +
+                        6 * M^3 * a^4 * epsilon * r^12 - M^2 * a^4 * epsilon * r^13 +
+                        4 * a^6 * r^14 - 8 * M * a^4 * r^15 + 4 * a^4 * r^16
+                    ) *
+                    cos_theta^3 +
+                    (
+                        M^4 * a^4 * epsilon^2 * r^10 +
+                        M^4 * a^2 * epsilon^2 * r^12 +
+                        2 * M^2 * a^4 * epsilon * r^13 +
+                        2 * M^3 * a^2 * epsilon * r^14 +
+                        a^4 * r^16 - 2 * M * a^2 * r^17 + a^2 * r^18
+                    ) * cos_theta
+                ) *
+                v_r *
+                v_theta *
+                sin_theta -
+                (
+                    (
+                        8 * M^7 * a^6 * epsilon^3 * r^5 +
+                        3 * M^6 * a^6 * epsilon^3 * r^6 +
+                        10 * M^5 * a^6 * epsilon^2 * r^8 +
+                        2 * M^5 * a^4 * epsilon^2 * r^10 - 4 * M^4 * a^4 * epsilon * r^12 +
+                        2 * M^3 * a^4 * epsilon * r^13 -
+                        (16 * M^6 * a^4 - 3 * M^4 * a^6) * epsilon^2 * r^9 +
+                        (2 * M^3 * a^6 * epsilon + 3 * M^4 * a^4 * epsilon^2) * r^11 -
+                        2 *
+                        (
+                            M^3 * a^16 * epsilon * r - 2 * M^4 * a^14 * epsilon * r^2 +
+                            M^3 * a^14 * epsilon * r^3
+                        ) *
+                        cos_theta^10 -
+                        (
+                            M^4 * a^14 * epsilon^2 * r - 4 * M^5 * a^12 * epsilon^2 * r^2 -
+                            12 * M^4 * a^12 * epsilon * r^4 +
+                            6 * M^3 * a^12 * epsilon * r^5 +
+                            (6 * M^3 * a^14 * epsilon + M^4 * a^12 * epsilon^2) * r^3
+                        ) * cos_theta^8 +
+                        (
+                            8 * M^6 * a^10 * epsilon^2 * r^3 -
+                            2 * M^5 * a^10 * epsilon^2 * r^4 -
+                            4 * M^3 * a^12 * epsilon * r^5 +
+                            8 * M^4 * a^10 * epsilon * r^6 -
+                            4 * M^3 * a^10 * epsilon * r^7 -
+                            (6 * M^5 * a^12 * epsilon^2 - M^6 * a^10 * epsilon^3) * r^2
+                        ) * cos_theta^6 -
+                        (
+                            M^6 * a^10 * epsilon^3 * r^2 - 4 * M^7 * a^8 * epsilon^3 * r^3 -
+                            6 * M^4 * a^10 * epsilon^2 * r^5 +
+                            14 * M^5 * a^8 * epsilon^2 * r^6 +
+                            8 * M^4 * a^8 * epsilon * r^8 - 4 * M^3 * a^8 * epsilon * r^9 -
+                            2 *
+                            (2 * M^3 * a^10 * epsilon + 3 * M^4 * a^8 * epsilon^2) *
+                            r^7 +
+                            2 * (M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3) * r^4
+                        ) * cos_theta^4 -
+                        (
+                            4 * M^7 * a^8 * epsilon^3 * r^3 -
+                            2 * M^6 * a^8 * epsilon^3 * r^4 +
+                            8 * M^7 * a^6 * epsilon^3 * r^5 +
+                            6 * M^5 * a^6 * epsilon^2 * r^8 +
+                            12 * M^4 * a^6 * epsilon * r^10 -
+                            6 * M^3 * a^6 * epsilon * r^11 +
+                            8 * (3 * M^6 * a^6 - M^4 * a^8) * epsilon^2 * r^7 -
+                            2 *
+                            (3 * M^3 * a^8 * epsilon + 4 * M^4 * a^6 * epsilon^2) *
+                            r^9 -
+                            (14 * M^5 * a^8 * epsilon^2 - 3 * M^6 * a^6 * epsilon^3) * r^6
+                        ) * cos_theta^2
+                    ) * sin_theta^6 +
+                    (
+                        8 * M^5 * a^6 * epsilon^2 * r^8 + 2 * M^5 * a^4 * epsilon^2 * r^10 -
+                        8 * M^2 * a^4 * r^15 - 8 * M^2 * a^2 * r^17 +
+                        2 * M * a^2 * r^18 +
+                        (8 * M^3 * a^2 + 4 * M * a^4 + M^2 * a^2 * epsilon) * r^16 +
+                        2 * (16 * M^5 * a^2 + 3 * M^3 * a^4) * epsilon * r^13 +
+                        2 * (M * a^6 - 2 * (5 * M^4 * a^2 - M^2 * a^4) * epsilon) * r^14 -
+                        2 *
+                        (
+                            M * a^20 - 4 * M^2 * a^18 * r - 4 * M^2 * a^16 * r^3 +
+                            M * a^16 * r^4 +
+                            2 * (2 * M^3 * a^16 + M * a^18) * r^2
+                        ) *
+                        cos_theta^14 - 3 * (12 * M^4 * a^4 - M^2 * a^6) * epsilon * r^12 -
+                        (
+                            M^2 * a^18 * epsilon - 6 * M^3 * a^16 * epsilon * r -
+                            40 * M^2 * a^14 * r^5 +
+                            10 * M * a^14 * r^6 +
+                            (40 * M^3 * a^14 + 20 * M * a^16 + 3 * M^2 * a^14 * epsilon) *
+                            r^4 - 10 * (4 * M^2 * a^16 + M^3 * a^14 * epsilon) * r^3 +
+                            2 *
+                            (5 * M * a^18 + 2 * (2 * M^4 * a^14 + M^2 * a^16) * epsilon) *
+                            r^2
+                        ) * cos_theta^12 -
+                        (16 * M^6 * a^4 - 3 * M^4 * a^6) * epsilon^2 * r^9 +
+                        (10 * M^3 * a^6 * epsilon + M^4 * a^4 * epsilon^2) * r^11 +
+                        (
+                            72 * M^2 * a^12 * r^7 - 18 * M * a^12 * r^8 -
+                            2 *
+                            (36 * M^3 * a^12 + 18 * M * a^14 + 7 * M^2 * a^12 * epsilon) *
+                            r^6 + 2 * (36 * M^2 * a^14 + 17 * M^3 * a^12 * epsilon) * r^5 -
+                            2 *
+                            (9 * M * a^16 + 2 * (M^4 * a^12 + 4 * M^2 * a^14) * epsilon) *
+                            r^4 +
+                            (
+                                3 * M^4 * a^12 * epsilon^2 -
+                                4 * (4 * M^5 * a^12 - M^3 * a^14) * epsilon
+                            ) * r^3 -
+                            2 *
+                            (
+                                M^5 * a^12 * epsilon^2 -
+                                (10 * M^4 * a^14 - M^2 * a^16) * epsilon
+                            ) *
+                            r^2 - (6 * M^3 * a^16 * epsilon - M^4 * a^14 * epsilon^2) * r
+                        ) * cos_theta^10 -
+                        (
+                            M^4 * a^14 * epsilon^2 * r - 6 * M^5 * a^12 * epsilon^2 * r^2 -
+                            40 * M^2 * a^10 * r^9 +
+                            10 * M * a^10 * r^10 +
+                            5 *
+                            (8 * M^3 * a^10 + 4 * M * a^12 + 5 * M^2 * a^10 * epsilon) *
+                            r^8 - 4 * (10 * M^2 * a^12 + 9 * M^3 * a^10 * epsilon) * r^7 +
+                            2 *
+                            (
+                                5 * M * a^14 -
+                                2 * (11 * M^4 * a^10 - 5 * M^2 * a^12) * epsilon
+                            ) *
+                            r^6 -
+                            2 *
+                            (
+                                4 * M^4 * a^10 * epsilon^2 -
+                                (16 * M^5 * a^10 + 19 * M^3 * a^12) * epsilon
+                            ) *
+                            r^5 -
+                            (
+                                4 * M^5 * a^10 * epsilon^2 +
+                                (44 * M^4 * a^12 + 5 * M^2 * a^14) * epsilon
+                            ) * r^4 +
+                            (
+                                14 * M^3 * a^14 * epsilon +
+                                (8 * M^6 * a^10 + 3 * M^4 * a^12) * epsilon^2
+                            ) * r^3
+                        ) * cos_theta^8 -
+                        2 *
+                        (
+                            2 * M^5 * a^12 * epsilon^2 * r^2 -
+                            4 * M^6 * a^10 * epsilon^2 * r^3 +
+                            2 * M^5 * a^10 * epsilon^2 * r^4 +
+                            20 * M^2 * a^8 * r^11 - 5 * M * a^8 * r^12 -
+                            10 * (2 * M^3 * a^8 + M * a^10 - M^2 * a^8 * epsilon) * r^10 +
+                            2 * (10 * M^2 * a^10 - M^3 * a^8 * epsilon) * r^9 -
+                            (5 * M * a^12 + 28 * M^4 * a^8 * epsilon) * r^8 -
+                            (
+                                3 * M^4 * a^8 * epsilon^2 +
+                                4 * (4 * M^5 * a^8 - 9 * M^3 * a^10) * epsilon
+                            ) * r^7 -
+                            2 *
+                            (
+                                3 * M^5 * a^8 * epsilon^2 -
+                                (6 * M^4 * a^10 - 5 * M^2 * a^12) * epsilon
+                            ) *
+                            r^6 -
+                            (2 * M^3 * a^12 * epsilon - 7 * M^4 * a^10 * epsilon^2) * r^5
+                        ) *
+                        cos_theta^6 +
+                        (
+                            6 * M^4 * a^10 * epsilon^2 * r^5 -
+                            24 * M^5 * a^8 * epsilon^2 * r^6 - 72 * M^2 * a^6 * r^13 +
+                            18 * M * a^6 * r^14 +
+                            (72 * M^3 * a^6 + 36 * M * a^8 - 5 * M^2 * a^6 * epsilon) * r^12 -
+                            2 * (36 * M^2 * a^8 + 7 * M^3 * a^6 * epsilon) * r^11 +
+                            2 * (64 * M^5 * a^6 - 19 * M^3 * a^8) * epsilon * r^9 +
+                            2 *
+                            (9 * M * a^10 - 2 * (4 * M^4 * a^6 - 5 * M^2 * a^8) * epsilon) *
+                            r^10 +
+                            (
+                                4 * M^5 * a^6 * epsilon^2 -
+                                (136 * M^4 * a^8 - 25 * M^2 * a^10) * epsilon
+                            ) * r^8 +
+                            2 *
+                            (
+                                18 * M^3 * a^10 * epsilon +
+                                (12 * M^6 * a^6 - 7 * M^4 * a^8) * epsilon^2
+                            ) *
+                            r^7
+                        ) * cos_theta^4 +
+                        (
+                            12 * M^5 * a^8 * epsilon^2 * r^6 -
+                            12 * M^5 * a^6 * epsilon^2 * r^8 - 40 * M^2 * a^4 * r^15 +
+                            10 * M * a^4 * r^16 +
+                            2 * (20 * M^3 * a^4 + 10 * M * a^6 + M^2 * a^4 * epsilon) * r^14 -
+                            2 * (20 * M^2 * a^6 + 3 * M^3 * a^4 * epsilon) * r^13 +
+                            2 *
+                            (5 * M * a^8 - 2 * (13 * M^4 * a^4 - 4 * M^2 * a^6) * epsilon) *
+                            r^12 -
+                            (
+                                M^4 * a^4 * epsilon^2 -
+                                4 * (28 * M^5 * a^4 + M^3 * a^6) * epsilon
+                            ) * r^11 -
+                            2 *
+                            (
+                                M^5 * a^4 * epsilon^2 +
+                                (62 * M^4 * a^6 - 7 * M^2 * a^8) * epsilon
+                            ) *
+                            r^10 - 8 * (3 * M^6 * a^6 - M^4 * a^8) * epsilon^2 * r^7 +
+                            (
+                                34 * M^3 * a^8 * epsilon +
+                                (16 * M^6 * a^4 - 3 * M^4 * a^6) * epsilon^2
+                            ) * r^9
+                        ) * cos_theta^2
+                    ) * sin_theta^4 -
+                    2 *
+                    (
+                        M^2 * a^4 * epsilon * r^14 - 2 * M^3 * a^2 * epsilon * r^15 +
+                        M^2 * a^2 * epsilon * r^16 +
+                        a^4 * r^17 - 4 * M * a^2 * r^18 - 4 * M * r^20 +
+                        r^21 +
+                        2 * (2 * M^2 + a^2) * r^19 +
+                        (
+                            a^20 * r - 4 * M * a^18 * r^2 - 4 * M * a^16 * r^4 +
+                            a^16 * r^5 +
+                            2 * (2 * M^2 * a^16 + a^18) * r^3
+                        ) * cos_theta^16 -
+                        (
+                            M^2 * a^16 * epsilon * r^2 + 32 * M * a^14 * r^6 -
+                            8 * a^14 * r^7 - 16 * (2 * M^2 * a^14 + a^16) * r^5 +
+                            (32 * M * a^16 + M^2 * a^14 * epsilon) * r^4 -
+                            2 * (4 * a^18 + M^3 * a^14 * epsilon) * r^3
+                        ) * cos_theta^14 +
+                        (
+                            M^2 * a^16 * epsilon * r^2 - 2 * M^3 * a^14 * epsilon * r^3 -
+                            5 * M^2 * a^14 * epsilon * r^4 - 112 * M * a^12 * r^8 +
+                            28 * a^12 * r^9 +
+                            56 * (2 * M^2 * a^12 + a^14) * r^7 -
+                            2 * (56 * M * a^14 + 3 * M^2 * a^12 * epsilon) * r^6 +
+                            4 * (7 * a^16 + 3 * M^3 * a^12 * epsilon) * r^5
+                        ) * cos_theta^12 +
+                        (
+                            6 * M^2 * a^14 * epsilon * r^4 -
+                            12 * M^3 * a^12 * epsilon * r^5 -
+                            9 * M^2 * a^12 * epsilon * r^6 - 224 * M * a^10 * r^10 +
+                            56 * a^10 * r^11 +
+                            112 * (2 * M^2 * a^10 + a^12) * r^9 -
+                            (224 * M * a^12 + 15 * M^2 * a^10 * epsilon) * r^8 +
+                            2 * (28 * a^14 + 15 * M^3 * a^10 * epsilon) * r^7
+                        ) * cos_theta^10 +
+                        5 *
+                        (
+                            3 * M^2 * a^12 * epsilon * r^6 -
+                            6 * M^3 * a^10 * epsilon * r^7 - M^2 * a^10 * epsilon * r^8 -
+                            56 * M * a^8 * r^12 +
+                            14 * a^8 * r^13 +
+                            28 * (2 * M^2 * a^8 + a^10) * r^11 -
+                            4 * (14 * M * a^10 + M^2 * a^8 * epsilon) * r^10 +
+                            2 * (7 * a^12 + 4 * M^3 * a^8 * epsilon) * r^9
+                        ) *
+                        cos_theta^8 +
+                        (
+                            20 * M^2 * a^10 * epsilon * r^8 -
+                            40 * M^3 * a^8 * epsilon * r^9 +
+                            5 * M^2 * a^8 * epsilon * r^10 - 224 * M * a^6 * r^14 +
+                            56 * a^6 * r^15 +
+                            112 * (2 * M^2 * a^6 + a^8) * r^13 -
+                            (224 * M * a^8 + 15 * M^2 * a^6 * epsilon) * r^12 +
+                            2 * (28 * a^10 + 15 * M^3 * a^6 * epsilon) * r^11
+                        ) * cos_theta^6 +
+                        (
+                            15 * M^2 * a^8 * epsilon * r^10 -
+                            30 * M^3 * a^6 * epsilon * r^11 +
+                            9 * M^2 * a^6 * epsilon * r^12 - 112 * M * a^4 * r^16 +
+                            28 * a^4 * r^17 +
+                            56 * (2 * M^2 * a^4 + a^6) * r^15 -
+                            2 * (56 * M * a^6 + 3 * M^2 * a^4 * epsilon) * r^14 +
+                            4 * (7 * a^8 + 3 * M^3 * a^4 * epsilon) * r^13
+                        ) * cos_theta^4 +
+                        (
+                            6 * M^2 * a^6 * epsilon * r^12 -
+                            12 * M^3 * a^4 * epsilon * r^13 +
+                            5 * M^2 * a^4 * epsilon * r^14 - 32 * M * a^2 * r^18 +
+                            8 * a^2 * r^19 +
+                            16 * (2 * M^2 * a^2 + a^4) * r^17 -
+                            (32 * M * a^4 + M^2 * a^2 * epsilon) * r^16 +
+                            2 * (4 * a^6 + M^3 * a^2 * epsilon) * r^15
+                        ) * cos_theta^2
+                    ) *
+                    sin_theta^2
+                ) * v_phi^2 -
+                (
+                    2 * M^4 * a^2 * epsilon^2 * r^11 +
+                    4 * M^2 * a^2 * epsilon * r^14 +
+                    4 * M^3 * epsilon * r^15 - 3 * M^2 * epsilon * r^16 + 2 * a^2 * r^17 -
+                    2 * M * r^18 +
+                    2 * (M * a^18 - a^18 * r) * cos_theta^18 +
+                    (
+                        M^2 * a^16 * epsilon + 2 * a^18 * r + 14 * M * a^16 * r^2 -
+                        16 * a^16 * r^3
+                    ) * cos_theta^16 +
+                    8 *
+                    (2 * a^16 * r^3 + 5 * M * a^14 * r^4 - 7 * a^14 * r^5) *
+                    cos_theta^14 +
+                    4 *
+                    (
+                        M^2 * a^14 * epsilon * r^2 + M^3 * a^12 * epsilon * r^3 -
+                        6 * M^2 * a^12 * epsilon * r^4 +
+                        14 * a^14 * r^5 +
+                        14 * M * a^12 * r^6 - 28 * a^12 * r^7
+                    ) *
+                    cos_theta^12 -
+                    2 *
+                    (
+                        M^4 * a^10 * epsilon^2 * r^3 - 12 * M^2 * a^12 * epsilon * r^4 -
+                        12 * M^3 * a^10 * epsilon * r^5 + 44 * M^2 * a^10 * epsilon * r^6 -
+                        56 * a^12 * r^7 - 14 * M * a^10 * r^8 + 70 * a^10 * r^9
+                    ) *
+                    cos_theta^10 +
+                    2 *
+                    (
+                        M^4 * a^10 * epsilon^2 * r^3 - 4 * M^4 * a^8 * epsilon^2 * r^5 +
+                        30 * M^2 * a^10 * epsilon * r^6 +
+                        30 * M^3 * a^8 * epsilon * r^7 - 75 * M^2 * a^8 * epsilon * r^8 +
+                        70 * a^10 * r^9 - 14 * M * a^8 * r^10 - 56 * a^8 * r^11
+                    ) *
+                    cos_theta^8 +
+                    4 *
+                    (
+                        2 * M^4 * a^8 * epsilon^2 * r^5 - 3 * M^4 * a^6 * epsilon^2 * r^7 +
+                        20 * M^2 * a^8 * epsilon * r^8 +
+                        20 * M^3 * a^6 * epsilon * r^9 - 36 * M^2 * a^6 * epsilon * r^10 +
+                        28 * a^8 * r^11 - 14 * M * a^6 * r^12 - 14 * a^6 * r^13
+                    ) *
+                    cos_theta^6 +
+                    4 *
+                    (
+                        3 * M^4 * a^6 * epsilon^2 * r^7 - 2 * M^4 * a^4 * epsilon^2 * r^9 +
+                        15 * M^2 * a^6 * epsilon * r^10 +
+                        15 * M^3 * a^4 * epsilon * r^11 - 20 * M^2 * a^4 * epsilon * r^12 +
+                        14 * a^6 * r^13 - 10 * M * a^4 * r^14 - 4 * a^4 * r^15
+                    ) *
+                    cos_theta^4 +
+                    2 *
+                    (
+                        4 * M^4 * a^4 * epsilon^2 * r^9 - M^4 * a^2 * epsilon^2 * r^11 +
+                        12 * M^2 * a^4 * epsilon * r^12 +
+                        12 * M^3 * a^2 * epsilon * r^13 - 12 * M^2 * a^2 * epsilon * r^14 +
+                        8 * a^4 * r^15 - 7 * M * a^2 * r^16 - a^2 * r^17
+                    ) *
+                    cos_theta^2
+                ) * v_r^2 +
+                4 *
+                (
+                    4 * M^7 * a^5 * epsilon^3 * r^5 + 9 * M^5 * a^5 * epsilon^2 * r^8 -
+                    16 * M^6 * a^3 * epsilon^2 * r^9 +
+                    8 * M^5 * a^3 * epsilon^2 * r^10 +
+                    6 * M^3 * a^5 * epsilon * r^11 - 20 * M^4 * a^3 * epsilon * r^12 -
+                    4 * M^2 * a * r^17 +
+                    M * a * r^18 +
+                    2 * (2 * M^3 * a + M * a^3) * r^16 +
+                    (
+                        M * a^19 - 4 * M^2 * a^17 * r - 4 * M^2 * a^15 * r^3 +
+                        M * a^15 * r^4 +
+                        2 * (2 * M^3 * a^15 + M * a^17) * r^2
+                    ) * cos_theta^16 - 4 * (M^2 * a^3 - M^3 * a * epsilon) * r^15 +
+                    2 * (8 * M^5 * a + 5 * M^3 * a^3) * epsilon * r^13 +
+                    (M * a^5 - 16 * M^4 * a * epsilon) * r^14 -
+                    (
+                        M * a^19 + 20 * M^2 * a^13 * r^5 - 5 * M * a^13 * r^6 -
+                        (20 * M^3 * a^13 + 9 * M * a^15) * r^4 +
+                        2 * (8 * M^2 * a^15 + M^3 * a^13 * epsilon) * r^3 +
+                        (4 * M^3 * a^15 - 3 * M * a^17 - 4 * M^4 * a^13 * epsilon) * r^2 -
+                        2 * (2 * M^2 * a^17 - M^3 * a^15 * epsilon) * r
+                    ) * cos_theta^14 +
+                    (
+                        6 * M^3 * a^15 * epsilon * r - 36 * M^2 * a^11 * r^7 +
+                        9 * M * a^11 * r^8 +
+                        (36 * M^3 * a^11 + 13 * M * a^13) * r^6 -
+                        4 * (4 * M^2 * a^13 + M^3 * a^11 * epsilon) * r^5 -
+                        (20 * M^3 * a^13 + M * a^15 - 4 * M^4 * a^11 * epsilon) * r^4 +
+                        2 *
+                        (10 * M^2 * a^15 + (4 * M^5 * a^11 + M^3 * a^13) * epsilon) *
+                        r^3 -
+                        (
+                            5 * M * a^17 + 16 * M^4 * a^13 * epsilon -
+                            M^5 * a^11 * epsilon^2
+                        ) * r^2
+                    ) * cos_theta^12 -
+                    (
+                        4 * M^3 * a^15 * epsilon * r - 16 * M^2 * a^11 * r^7 +
+                        20 * M^2 * a^9 * r^9 - 5 * M * a^9 * r^10 -
+                        (20 * M^3 * a^9 + M * a^11) * r^8 +
+                        (36 * M^3 * a^11 + 13 * M * a^13 + 8 * M^4 * a^9 * epsilon) * r^6 -
+                        2 *
+                        (18 * M^2 * a^13 + (8 * M^5 * a^9 + 7 * M^3 * a^11) * epsilon) *
+                        r^5 +
+                        (
+                            9 * M * a^15 +
+                            32 * M^4 * a^11 * epsilon +
+                            3 * M^5 * a^9 * epsilon^2
+                        ) * r^4 -
+                        2 *
+                        (
+                            4 * M^6 * a^9 * epsilon^2 -
+                            (4 * M^5 * a^11 - 5 * M^3 * a^13) * epsilon
+                        ) *
+                        r^3 -
+                        (12 * M^4 * a^13 * epsilon - 7 * M^5 * a^11 * epsilon^2) * r^2
+                    ) * cos_theta^10 +
+                    (
+                        11 * M^5 * a^11 * epsilon^2 * r^2 +
+                        40 * M^2 * a^9 * r^9 +
+                        20 * M^2 * a^7 * r^11 - 5 * M * a^7 * r^12 -
+                        5 * (4 * M^3 * a^7 + 3 * M * a^9) * r^10 -
+                        (20 * M^3 * a^9 + 15 * M * a^11 - 8 * M^4 * a^7 * epsilon) * r^8 +
+                        4 * (5 * M^2 * a^11 - 4 * M^5 * a^7 * epsilon) * r^7 -
+                        2 * (8 * M^5 * a^9 + 5 * M^3 * a^11) * epsilon * r^5 -
+                        (5 * M * a^13 - 16 * M^4 * a^9 * epsilon + M^5 * a^7 * epsilon^2) *
+                        r^6 +
+                        (28 * M^4 * a^11 * epsilon + 5 * M^5 * a^9 * epsilon^2) * r^4 -
+                        2 *
+                        (
+                            5 * M^3 * a^13 * epsilon + 8 * M^6 * a^9 * epsilon^2 -
+                            M^7 * a^7 * epsilon^3
+                        ) *
+                        r^3
+                    ) * cos_theta^8 -
+                    (
+                        5 * M^5 * a^11 * epsilon^2 * r^2 +
+                        M^5 * a^9 * epsilon^2 * r^4 +
+                        4 * M^7 * a^5 * epsilon^3 * r^5 - 36 * M^2 * a^5 * r^13 +
+                        9 * M * a^5 * r^14 +
+                        (36 * M^3 * a^5 + 13 * M * a^7) * r^12 -
+                        2 * (8 * M^2 * a^7 - 5 * M^3 * a^5 * epsilon) * r^11 -
+                        (20 * M^3 * a^7 + M * a^9 + 52 * M^4 * a^5 * epsilon) * r^10 +
+                        2 *
+                        (10 * M^2 * a^9 + (32 * M^5 * a^5 + 15 * M^3 * a^7) * epsilon) *
+                        r^9 -
+                        (
+                            5 * M * a^11 +
+                            64 * M^4 * a^7 * epsilon +
+                            11 * M^5 * a^5 * epsilon^2
+                        ) * r^8 +
+                        4 *
+                        (
+                            6 * M^6 * a^5 * epsilon^2 -
+                            (4 * M^5 * a^7 - 5 * M^3 * a^9) * epsilon
+                        ) *
+                        r^7 +
+                        (8 * M^4 * a^9 * epsilon - 15 * M^5 * a^7 * epsilon^2) * r^6 -
+                        2 * (4 * M^6 * a^9 * epsilon^2 - 3 * M^7 * a^7 * epsilon^3) * r^3
+                    ) * cos_theta^6 +
+                    (
+                        6 * M^7 * a^7 * epsilon^3 * r^3 - M^5 * a^9 * epsilon^2 * r^4 +
+                        12 * M^7 * a^5 * epsilon^3 * r^5 -
+                        27 * M^5 * a^7 * epsilon^2 * r^6 + 20 * M^2 * a^3 * r^15 -
+                        5 * M * a^3 * r^16 - (20 * M^3 * a^3 + M * a^5) * r^14 -
+                        4 * (4 * M^2 * a^5 + 3 * M^3 * a^3 * epsilon) * r^13 +
+                        (36 * M^3 * a^5 + 13 * M * a^7 + 52 * M^4 * a^3 * epsilon) * r^12 -
+                        2 *
+                        (18 * M^2 * a^7 + (28 * M^5 * a^3 + 11 * M^3 * a^5) * epsilon) *
+                        r^11 +
+                        (
+                            9 * M * a^9 +
+                            16 * M^4 * a^5 * epsilon +
+                            8 * M^5 * a^3 * epsilon^2
+                        ) * r^10 -
+                        2 *
+                        (
+                            8 * M^6 * a^3 * epsilon^2 -
+                            (32 * M^5 * a^5 + 5 * M^3 * a^7) * epsilon
+                        ) *
+                        r^9 -
+                        (72 * M^4 * a^7 * epsilon + 13 * M^5 * a^5 * epsilon^2) * r^8 +
+                        4 * (5 * M^3 * a^9 * epsilon + 12 * M^6 * a^5 * epsilon^2) * r^7
+                    ) * cos_theta^4 -
+                    (
+                        2 * M^7 * a^7 * epsilon^3 * r^3 + 12 * M^7 * a^5 * epsilon^3 * r^5 -
+                        13 * M^5 * a^7 * epsilon^2 * r^6 +
+                        24 * M^6 * a^5 * epsilon^2 * r^7 +
+                        7 * M^5 * a^5 * epsilon^2 * r^8 - 4 * M^2 * a * r^17 +
+                        M * a * r^18 +
+                        (4 * M^3 * a - 3 * M * a^3) * r^16 +
+                        4 * (4 * M^2 * a^3 + M^3 * a * epsilon) * r^15 -
+                        (20 * M^3 * a^3 + 9 * M * a^5 + 16 * M^4 * a * epsilon) * r^14 +
+                        2 * (10 * M^2 * a^5 + (8 * M^5 * a - M^3 * a^3) * epsilon) * r^13 -
+                        2 * (28 * M^5 * a^3 + 13 * M^3 * a^5) * epsilon * r^11 -
+                        (5 * M * a^7 - 32 * M^4 * a^3 * epsilon) * r^12 +
+                        4 * (17 * M^4 * a^5 * epsilon + 4 * M^5 * a^3 * epsilon^2) * r^10 -
+                        4 * (5 * M^3 * a^7 * epsilon + 8 * M^6 * a^3 * epsilon^2) * r^9
+                    ) * cos_theta^2
+                ) *
+                v_phi *
+                v_t -
+                (
+                    8 * M^7 * a^4 * epsilon^3 * r^5 - 3 * M^6 * a^4 * epsilon^3 * r^6 +
+                    18 * M^5 * a^4 * epsilon^2 * r^8 +
+                    28 * M^5 * a^2 * epsilon^2 * r^10 - 8 * M^2 * r^17 +
+                    2 * M * r^18 +
+                    (8 * M^3 + 4 * M * a^2 - 3 * M^2 * epsilon) * r^16 -
+                    4 * (2 * M^2 * a^2 - 5 * M^3 * epsilon) * r^15 +
+                    32 * (M^5 + M^3 * a^2) * epsilon * r^13 +
+                    2 * (M * a^4 - (22 * M^4 + 3 * M^2 * a^2) * epsilon) * r^14 -
+                    2 *
+                    (
+                        M * a^18 - 4 * M^2 * a^16 * r - 4 * M^2 * a^14 * r^3 +
+                        M * a^14 * r^4 +
+                        2 * (2 * M^3 * a^14 + M * a^16) * r^2
+                    ) *
+                    cos_theta^14 - (40 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon * r^12 +
+                    (
+                        M^2 * a^16 * epsilon +
+                        40 * M^2 * a^14 * r^3 +
+                        40 * M^2 * a^12 * r^5 - 10 * M * a^12 * r^6 -
+                        (40 * M^3 * a^12 + 20 * M * a^14 - M^2 * a^12 * epsilon) * r^4 -
+                        2 * (5 * M * a^16 + (2 * M^4 * a^12 - M^2 * a^14) * epsilon) * r^2
+                    ) * cos_theta^12 -
+                    2 * (16 * M^6 * a^2 + 3 * M^4 * a^4) * epsilon^2 * r^9 +
+                    6 * (2 * M^3 * a^4 * epsilon - M^4 * a^2 * epsilon^2) * r^11 +
+                    2 *
+                    (
+                        36 * M^2 * a^12 * r^5 + 36 * M^2 * a^10 * r^7 - 9 * M * a^10 * r^8 -
+                        (36 * M^3 * a^10 + 18 * M * a^12 - M^2 * a^10 * epsilon) * r^6 -
+                        (9 * M * a^14 - 2 * M^2 * a^12 * epsilon) * r^4 -
+                        (
+                            M^4 * a^10 * epsilon^2 +
+                            4 * (2 * M^5 * a^10 + M^3 * a^12) * epsilon
+                        ) * r^3 +
+                        (
+                            M^5 * a^10 * epsilon^2 +
+                            (12 * M^4 * a^12 + M^2 * a^14) * epsilon
+                        ) * r^2 - (4 * M^3 * a^14 * epsilon + M^4 * a^12 * epsilon^2) * r
+                    ) *
+                    cos_theta^10 +
+                    (
+                        2 * M^4 * a^12 * epsilon^2 * r - 32 * M^5 * a^8 * epsilon * r^5 +
+                        40 * M^2 * a^8 * r^9 - 10 * M * a^8 * r^10 -
+                        5 * (8 * M^3 * a^8 + 4 * M * a^10 + M^2 * a^8 * epsilon) * r^8 +
+                        20 * (2 * M^2 * a^10 + M^3 * a^8 * epsilon) * r^7 -
+                        2 *
+                        (5 * M * a^12 + (2 * M^4 * a^8 + 5 * M^2 * a^10) * epsilon) *
+                        r^6 +
+                        (
+                            6 * M^5 * a^8 * epsilon^2 +
+                            (56 * M^4 * a^10 - 5 * M^2 * a^12) * epsilon
+                        ) * r^4 -
+                        2 *
+                        (
+                            10 * M^3 * a^12 * epsilon +
+                            (8 * M^6 * a^8 - M^4 * a^10) * epsilon^2
+                        ) *
+                        r^3 + (8 * M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3) * r^2
+                    ) * cos_theta^8 +
+                    2 *
+                    (
+                        6 * M^4 * a^8 * epsilon^2 * r^5 - 20 * M^2 * a^6 * r^11 +
+                        5 * M * a^6 * r^12 +
+                        10 * (2 * M^3 * a^6 + M * a^8 - M^2 * a^6 * epsilon) * r^10 -
+                        20 * (M^2 * a^8 - 2 * M^3 * a^6 * epsilon) * r^9 +
+                        (5 * M * a^10 - 4 * (12 * M^4 * a^6 + 5 * M^2 * a^8) * epsilon) *
+                        r^8 +
+                        2 *
+                        (
+                            3 * M^4 * a^6 * epsilon^2 +
+                            4 * (2 * M^5 * a^6 + 5 * M^3 * a^8) * epsilon
+                        ) *
+                        r^7 -
+                        (
+                            11 * M^5 * a^6 * epsilon^2 +
+                            2 * (4 * M^4 * a^8 + 5 * M^2 * a^10) * epsilon
+                        ) * r^6 -
+                        (2 * M^5 * a^8 * epsilon^2 + M^6 * a^6 * epsilon^3) * r^4 +
+                        2 * (4 * M^6 * a^8 * epsilon^2 - M^7 * a^6 * epsilon^3) * r^3 -
+                        (5 * M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3) * r^2
+                    ) *
+                    cos_theta^6 +
+                    (
+                        M^6 * a^8 * epsilon^3 * r^2 + 8 * M^7 * a^6 * epsilon^3 * r^3 -
+                        72 * M^2 * a^4 * r^13 +
+                        18 * M * a^4 * r^14 +
+                        (72 * M^3 * a^4 + 36 * M * a^6 - 25 * M^2 * a^4 * epsilon) * r^12 -
+                        24 * (3 * M^2 * a^6 - 5 * M^3 * a^4 * epsilon) * r^11 +
+                        2 *
+                        (9 * M * a^8 - (102 * M^4 * a^4 + 25 * M^2 * a^6) * epsilon) *
+                        r^10 +
+                        16 *
+                        (
+                            M^4 * a^4 * epsilon^2 +
+                            2 * (4 * M^5 * a^4 + 5 * M^3 * a^6) * epsilon
+                        ) *
+                        r^9 -
+                        (
+                            54 * M^5 * a^4 * epsilon^2 +
+                            (144 * M^4 * a^6 + 25 * M^2 * a^8) * epsilon
+                        ) * r^8 +
+                        4 *
+                        (
+                            10 * M^3 * a^8 * epsilon +
+                            (12 * M^6 * a^4 + M^4 * a^6) * epsilon^2
+                        ) *
+                        r^7 -
+                        (4 * M^5 * a^6 * epsilon^2 + 3 * M^6 * a^4 * epsilon^3) * r^6 -
+                        4 * (3 * M^4 * a^8 * epsilon^2 - 2 * M^7 * a^4 * epsilon^3) * r^5 -
+                        2 * (M^5 * a^8 * epsilon^2 - 2 * M^6 * a^6 * epsilon^3) * r^4
+                    ) * cos_theta^4 -
+                    2 *
+                    (
+                        2 * M^7 * a^6 * epsilon^3 * r^3 +
+                        M^6 * a^6 * epsilon^3 * r^4 +
+                        8 * M^7 * a^4 * epsilon^3 * r^5 - 18 * M^5 * a^4 * epsilon^2 * r^8 +
+                        20 * M^2 * a^2 * r^15 - 5 * M * a^2 * r^16 -
+                        (20 * M^3 * a^2 + 10 * M * a^4 - 7 * M^2 * a^2 * epsilon) * r^14 +
+                        20 * (M^2 * a^4 - 2 * M^3 * a^2 * epsilon) * r^13 -
+                        (5 * M * a^6 - 2 * (40 * M^4 * a^2 + 7 * M^2 * a^4) * epsilon) *
+                        r^12 -
+                        (
+                            3 * M^4 * a^2 * epsilon^2 +
+                            4 * (14 * M^5 * a^2 + 15 * M^3 * a^4) * epsilon
+                        ) * r^11 +
+                        (
+                            14 * M^5 * a^2 * epsilon^2 +
+                            (68 * M^4 * a^4 + 7 * M^2 * a^6) * epsilon
+                        ) * r^10 +
+                        8 * (3 * M^6 * a^4 + M^4 * a^6) * epsilon^2 * r^7 -
+                        (
+                            20 * M^3 * a^6 * epsilon +
+                            (16 * M^6 * a^2 - 5 * M^4 * a^4) * epsilon^2
+                        ) * r^9 -
+                        (13 * M^5 * a^6 * epsilon^2 + 3 * M^6 * a^4 * epsilon^3) * r^6
+                    ) *
+                    cos_theta^2
+                ) * v_t^2 +
+                2 *
+                (
+                    M^4 * a^4 * epsilon^2 * r^11 + 2 * M^2 * a^4 * epsilon * r^14 -
+                    4 * M^3 * a^2 * epsilon * r^15 +
+                    2 * M^2 * a^2 * epsilon * r^16 +
+                    a^4 * r^17 - 4 * M * a^2 * r^18 - 4 * M * r^20 +
+                    r^21 +
+                    2 * (2 * M^2 + a^2) * r^19 +
+                    (
+                        a^20 * r - 4 * M * a^18 * r^2 - 4 * M * a^16 * r^4 +
+                        a^16 * r^5 +
+                        2 * (2 * M^2 * a^16 + a^18) * r^3
+                    ) * cos_theta^16 -
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r^2 + 16 * M * a^14 * r^6 - 4 * a^14 * r^7 -
+                        8 * (2 * M^2 * a^14 + a^16) * r^5 +
+                        (16 * M * a^16 + M^2 * a^14 * epsilon) * r^4 -
+                        2 * (2 * a^18 + M^3 * a^14 * epsilon) * r^3
+                    ) *
+                    cos_theta^14 +
+                    (
+                        2 * M^2 * a^16 * epsilon * r^2 - 10 * M^2 * a^14 * epsilon * r^4 -
+                        112 * M * a^12 * r^8 +
+                        28 * a^12 * r^9 +
+                        56 * (2 * M^2 * a^12 + a^14) * r^7 -
+                        4 * (28 * M * a^14 + 3 * M^2 * a^12 * epsilon) * r^6 +
+                        4 * (7 * a^16 + 6 * M^3 * a^12 * epsilon) * r^5 -
+                        (4 * M^3 * a^14 * epsilon - M^4 * a^12 * epsilon^2) * r^3
+                    ) * cos_theta^12 -
+                    2 *
+                    (
+                        M^4 * a^12 * epsilon^2 * r^3 - 6 * M^2 * a^14 * epsilon * r^4 +
+                        9 * M^2 * a^12 * epsilon * r^6 +
+                        112 * M * a^10 * r^10 - 28 * a^10 * r^11 -
+                        56 * (2 * M^2 * a^10 + a^12) * r^9 +
+                        (112 * M * a^12 + 15 * M^2 * a^10 * epsilon) * r^8 -
+                        2 * (14 * a^14 + 15 * M^3 * a^10 * epsilon) * r^7 +
+                        2 * (6 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * r^5
+                    ) *
+                    cos_theta^10 +
+                    (
+                        M^4 * a^12 * epsilon^2 * r^3 - 8 * M^4 * a^10 * epsilon^2 * r^5 +
+                        30 * M^2 * a^12 * epsilon * r^6 - 10 * M^2 * a^10 * epsilon * r^8 -
+                        280 * M * a^8 * r^12 +
+                        70 * a^8 * r^13 +
+                        140 * (2 * M^2 * a^8 + a^10) * r^11 -
+                        40 * (7 * M * a^10 + M^2 * a^8 * epsilon) * r^10 +
+                        10 * (7 * a^12 + 8 * M^3 * a^8 * epsilon) * r^9 -
+                        6 * (10 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * r^7
+                    ) * cos_theta^8 +
+                    2 *
+                    (
+                        2 * M^4 * a^10 * epsilon^2 * r^5 - 6 * M^4 * a^8 * epsilon^2 * r^7 +
+                        20 * M^2 * a^10 * epsilon * r^8 +
+                        5 * M^2 * a^8 * epsilon * r^10 - 112 * M * a^6 * r^14 +
+                        28 * a^6 * r^15 +
+                        56 * (2 * M^2 * a^6 + a^8) * r^13 -
+                        (112 * M * a^8 + 15 * M^2 * a^6 * epsilon) * r^12 +
+                        2 * (14 * a^10 + 15 * M^3 * a^6 * epsilon) * r^11 -
+                        2 * (20 * M^3 * a^8 * epsilon - M^4 * a^6 * epsilon^2) * r^9
+                    ) *
+                    cos_theta^6 +
+                    (
+                        6 * M^4 * a^8 * epsilon^2 * r^7 - 8 * M^4 * a^6 * epsilon^2 * r^9 +
+                        30 * M^2 * a^8 * epsilon * r^10 +
+                        18 * M^2 * a^6 * epsilon * r^12 - 112 * M * a^4 * r^16 +
+                        28 * a^4 * r^17 +
+                        56 * (2 * M^2 * a^4 + a^6) * r^15 -
+                        4 * (28 * M * a^6 + 3 * M^2 * a^4 * epsilon) * r^14 +
+                        4 * (7 * a^8 + 6 * M^3 * a^4 * epsilon) * r^13 -
+                        (60 * M^3 * a^6 * epsilon - M^4 * a^4 * epsilon^2) * r^11
+                    ) * cos_theta^4 +
+                    2 *
+                    (
+                        2 * M^4 * a^6 * epsilon^2 * r^9 - M^4 * a^4 * epsilon^2 * r^11 +
+                        6 * M^2 * a^6 * epsilon * r^12 - 12 * M^3 * a^4 * epsilon * r^13 +
+                        5 * M^2 * a^4 * epsilon * r^14 - 16 * M * a^2 * r^18 +
+                        4 * a^2 * r^19 +
+                        8 * (2 * M^2 * a^2 + a^4) * r^17 -
+                        (16 * M * a^4 + M^2 * a^2 * epsilon) * r^16 +
+                        2 * (2 * a^6 + M^3 * a^2 * epsilon) * r^15
+                    ) *
+                    cos_theta^2
+                ) *
+                v_theta^2
+            ) / (
+                M^4 * a^2 * epsilon^2 * r^12 + 2 * M^2 * a^2 * epsilon * r^15 -
+                2 * M^3 * epsilon * r^16 +
+                M^2 * epsilon * r^17 +
+                a^2 * r^18 - 2 * M * r^19 +
+                r^20 +
+                (a^20 - 2 * M * a^18 * r + a^18 * r^2) * cos_theta^18 -
+                (
+                    M^2 * a^16 * epsilon * r - 9 * a^18 * r^2 + 18 * M * a^16 * r^3 -
+                    9 * a^16 * r^4
+                ) * cos_theta^16 +
+                2 *
+                (
+                    M^2 * a^16 * epsilon * r - M^3 * a^14 * epsilon * r^2 -
+                    3 * M^2 * a^14 * epsilon * r^3 + 18 * a^16 * r^4 - 36 * M * a^14 * r^5 +
+                    18 * a^14 * r^6
+                ) *
+                cos_theta^14 -
+                (
+                    M^4 * a^12 * epsilon^2 * r^2 - 14 * M^2 * a^14 * epsilon * r^3 +
+                    14 * M^3 * a^12 * epsilon * r^4 +
+                    14 * M^2 * a^12 * epsilon * r^5 - 84 * a^14 * r^6 +
+                    168 * M * a^12 * r^7 - 84 * a^12 * r^8
+                ) * cos_theta^12 +
+                (
+                    M^4 * a^12 * epsilon^2 * r^2 - 5 * M^4 * a^10 * epsilon^2 * r^4 +
+                    42 * M^2 * a^12 * epsilon * r^5 - 42 * M^3 * a^10 * epsilon * r^6 -
+                    14 * M^2 * a^10 * epsilon * r^7 + 126 * a^12 * r^8 -
+                    252 * M * a^10 * r^9 + 126 * a^10 * r^10
+                ) * cos_theta^10 +
+                (
+                    5 * M^4 * a^10 * epsilon^2 * r^4 - 10 * M^4 * a^8 * epsilon^2 * r^6 +
+                    70 * M^2 * a^10 * epsilon * r^7 - 70 * M^3 * a^8 * epsilon * r^8 +
+                    126 * a^10 * r^10 - 252 * M * a^8 * r^11 + 126 * a^8 * r^12
+                ) * cos_theta^8 +
+                2 *
+                (
+                    5 * M^4 * a^8 * epsilon^2 * r^6 - 5 * M^4 * a^6 * epsilon^2 * r^8 +
+                    35 * M^2 * a^8 * epsilon * r^9 - 35 * M^3 * a^6 * epsilon * r^10 +
+                    7 * M^2 * a^6 * epsilon * r^11 +
+                    42 * a^8 * r^12 - 84 * M * a^6 * r^13 + 42 * a^6 * r^14
+                ) *
+                cos_theta^6 +
+                (
+                    10 * M^4 * a^6 * epsilon^2 * r^8 - 5 * M^4 * a^4 * epsilon^2 * r^10 +
+                    42 * M^2 * a^6 * epsilon * r^11 - 42 * M^3 * a^4 * epsilon * r^12 +
+                    14 * M^2 * a^4 * epsilon * r^13 +
+                    36 * a^6 * r^14 - 72 * M * a^4 * r^15 + 36 * a^4 * r^16
+                ) * cos_theta^4 +
+                (
+                    5 * M^4 * a^4 * epsilon^2 * r^10 - M^4 * a^2 * epsilon^2 * r^12 +
+                    14 * M^2 * a^4 * epsilon * r^13 - 14 * M^3 * a^2 * epsilon * r^14 +
+                    6 * M^2 * a^2 * epsilon * r^15 +
+                    9 * a^4 * r^16 - 18 * M * a^2 * r^17 + 9 * a^2 * r^18
+                ) * cos_theta^2
+            )
+        out3 =
+            (
+                (
+                    (
+                        a^22 - 6 * M * a^20 * r - 6 * M * a^16 * r^5 +
+                        a^16 * r^6 +
+                        3 * (4 * M^2 * a^16 + a^18) * r^4 -
+                        4 * (2 * M^3 * a^16 + 3 * M * a^18) * r^3 +
+                        3 * (4 * M^2 * a^18 + a^20) * r^2
+                    ) * cos_theta^17 -
+                    2 *
+                    (
+                        M^2 * a^18 * epsilon * r + 24 * M * a^14 * r^7 - 4 * a^14 * r^8 -
+                        12 * (4 * M^2 * a^14 + a^16) * r^6 +
+                        (32 * M^3 * a^14 + 48 * M * a^16 + M^2 * a^14 * epsilon) * r^5 -
+                        4 * (12 * M^2 * a^16 + 3 * a^18 + M^3 * a^14 * epsilon) * r^4 +
+                        2 *
+                        (12 * M * a^18 + (2 * M^4 * a^14 + M^2 * a^16) * epsilon) *
+                        r^3 - 4 * (a^20 + M^3 * a^16 * epsilon) * r^2
+                    ) *
+                    cos_theta^15 +
+                    (
+                        2 * M * a^20 * r - 166 * M * a^12 * r^9 +
+                        28 * a^12 * r^10 +
+                        4 * (82 * M^2 * a^12 + 21 * a^14) * r^8 -
+                        2 *
+                        (108 * M^3 * a^12 + 164 * M * a^14 + 7 * M^2 * a^12 * epsilon) *
+                        r^7 +
+                        2 *
+                        (156 * M^2 * a^14 + 42 * a^16 + 29 * M^3 * a^12 * epsilon) *
+                        r^6 +
+                        4 *
+                        (
+                            4 * M^3 * a^14 - 39 * M * a^16 -
+                            (16 * M^4 * a^12 + 7 * M^2 * a^14) * epsilon
+                        ) *
+                        r^5 -
+                        (
+                            24 * M^2 * a^16 - 28 * a^18 - M^4 * a^12 * epsilon^2 -
+                            4 * (2 * M^5 * a^12 + 15 * M^3 * a^14) * epsilon
+                        ) * r^4 +
+                        2 *
+                        (
+                            4 * M^3 * a^16 + 4 * M * a^18 - M^5 * a^12 * epsilon^2 -
+                            (4 * M^4 * a^14 + 7 * M^2 * a^16) * epsilon
+                        ) *
+                        r^3 -
+                        (
+                            8 * M^2 * a^18 - 2 * M^3 * a^16 * epsilon -
+                            M^4 * a^14 * epsilon^2
+                        ) * r^2
+                    ) * cos_theta^13 +
+                    2 *
+                    (
+                        M^2 * a^18 * epsilon * r - 162 * M * a^10 * r^11 +
+                        28 * a^10 * r^12 +
+                        12 * (26 * M^2 * a^10 + 7 * a^12) * r^10 -
+                        4 *
+                        (50 * M^3 * a^10 + 78 * M * a^12 + 5 * M^2 * a^10 * epsilon) *
+                        r^9 +
+                        4 *
+                        (66 * M^2 * a^12 + 21 * a^14 + 20 * M^3 * a^10 * epsilon) *
+                        r^8 +
+                        2 *
+                        (
+                            24 * M^3 * a^12 - 66 * M * a^14 -
+                            (42 * M^4 * a^10 + 19 * M^2 * a^12) * epsilon
+                        ) *
+                        r^7 -
+                        2 *
+                        (
+                            36 * M^2 * a^14 - 14 * a^16 - 2 * M^4 * a^10 * epsilon^2 -
+                            (4 * M^5 * a^10 + 33 * M^3 * a^12) * epsilon
+                        ) *
+                        r^6 +
+                        (
+                            24 * M^3 * a^14 + 24 * M * a^16 - 10 * M^5 * a^10 * epsilon^2 +
+                            3 * (8 * M^4 * a^12 - 5 * M^2 * a^14) * epsilon
+                        ) * r^5 -
+                        (
+                            24 * M^2 * a^16 -
+                            (4 * M^6 * a^10 + 5 * M^4 * a^12) * epsilon^2 +
+                            8 * (2 * M^5 * a^12 + 3 * M^3 * a^14) * epsilon
+                        ) * r^4 +
+                        2 *
+                        (
+                            3 * M * a^18 - 2 * M^5 * a^12 * epsilon^2 +
+                            2 * (6 * M^4 * a^14 + M^2 * a^16) * epsilon
+                        ) *
+                        r^3 - (10 * M^3 * a^16 * epsilon - M^4 * a^14 * epsilon^2) * r^2
+                    ) *
+                    cos_theta^11 -
+                    (
+                        390 * M * a^8 * r^13 - 70 * a^8 * r^14 -
+                        30 * (24 * M^2 * a^8 + 7 * a^10) * r^12 +
+                        20 *
+                        (22 * M^3 * a^8 + 36 * M * a^10 + 3 * M^2 * a^8 * epsilon) *
+                        r^11 -
+                        10 *
+                        (48 * M^2 * a^10 + 21 * a^12 + 22 * M^3 * a^8 * epsilon) *
+                        r^10 -
+                        4 *
+                        (
+                            60 * M^3 * a^10 - 60 * M * a^12 -
+                            (48 * M^4 * a^8 + 25 * M^2 * a^10) * epsilon
+                        ) *
+                        r^9 +
+                        2 *
+                        (
+                            180 * M^2 * a^12 - 35 * a^14 - 9 * M^4 * a^8 * epsilon^2 +
+                            8 * (M^5 * a^8 - 5 * M^3 * a^10) * epsilon
+                        ) *
+                        r^8 -
+                        2 *
+                        (
+                            60 * M^3 * a^12 + 60 * M * a^14 - 17 * M^5 * a^8 * epsilon^2 +
+                            (132 * M^4 * a^10 - 5 * M^2 * a^12) * epsilon
+                        ) *
+                        r^7 +
+                        2 *
+                        (
+                            60 * M^2 * a^14 - 7 * M^4 * a^10 * epsilon^2 +
+                            7 * (8 * M^5 * a^10 + 15 * M^3 * a^12) * epsilon
+                        ) *
+                        r^6 -
+                        2 *
+                        (
+                            15 * M * a^16 + 16 * M^5 * a^10 * epsilon^2 -
+                            M^6 * a^8 * epsilon^3 +
+                            4 * (18 * M^4 * a^12 + 5 * M^2 * a^14) * epsilon
+                        ) *
+                        r^5 -
+                        (
+                            2 * M^7 * a^8 * epsilon^3 -
+                            (40 * M^6 * a^10 + 11 * M^4 * a^12) * epsilon^2 +
+                            12 * (2 * M^5 * a^12 - 5 * M^3 * a^14) * epsilon
+                        ) * r^4 -
+                        2 *
+                        (
+                            18 * M^5 * a^12 * epsilon^2 - M^6 * a^10 * epsilon^3 -
+                            (16 * M^4 * a^14 - 5 * M^2 * a^16) * epsilon
+                        ) *
+                        r^3 -
+                        (10 * M^3 * a^16 * epsilon - 7 * M^4 * a^14 * epsilon^2) * r^2
+                    ) * cos_theta^9 +
+                    2 *
+                    (
+                        2 * M^4 * a^14 * epsilon^2 * r^2 - 148 * M * a^6 * r^15 +
+                        28 * a^6 * r^16 +
+                        4 * (64 * M^2 * a^6 + 21 * a^8) * r^14 -
+                        (144 * M^3 * a^6 + 256 * M * a^8 + 25 * M^2 * a^6 * epsilon) *
+                        r^13 +
+                        4 * (24 * M^2 * a^8 + 21 * a^10 + 20 * M^3 * a^6 * epsilon) * r^12 +
+                        2 *
+                        (
+                            80 * M^3 * a^8 - 24 * M * a^10 -
+                            (22 * M^4 * a^6 + 15 * M^2 * a^8) * epsilon
+                        ) *
+                        r^11 -
+                        4 *
+                        (
+                            60 * M^2 * a^10 - 7 * a^12 - 2 * M^4 * a^6 * epsilon^2 +
+                            2 * (4 * M^5 * a^6 + 5 * M^3 * a^8) * epsilon
+                        ) *
+                        r^10 +
+                        (
+                            80 * M^3 * a^10 + 80 * M * a^12 - 8 * M^5 * a^6 * epsilon^2 +
+                            (208 * M^4 * a^8 + 25 * M^2 * a^10) * epsilon
+                        ) * r^9 -
+                        4 *
+                        (
+                            20 * M^2 * a^12 +
+                            (3 * M^6 * a^6 + M^4 * a^8) * epsilon^2 +
+                            8 * (2 * M^5 * a^8 + 5 * M^3 * a^10) * epsilon
+                        ) *
+                        r^8 +
+                        (
+                            20 * M * a^14 + 44 * M^5 * a^8 * epsilon^2 -
+                            M^6 * a^6 * epsilon^3 +
+                            8 * (6 * M^4 * a^10 + 5 * M^2 * a^12) * epsilon
+                        ) * r^7 -
+                        2 *
+                        (
+                            M^7 * a^6 * epsilon^3 +
+                            2 * (6 * M^6 * a^8 + 5 * M^4 * a^10) * epsilon^2 -
+                            2 * (12 * M^5 * a^10 - 5 * M^3 * a^12) * epsilon
+                        ) *
+                        r^6 +
+                        2 *
+                        (
+                            6 * M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3 -
+                            (32 * M^4 * a^12 - 5 * M^2 * a^14) * epsilon
+                        ) *
+                        r^5 +
+                        2 *
+                        (
+                            10 * M^3 * a^14 * epsilon - 3 * M^7 * a^8 * epsilon^3 +
+                            (14 * M^6 * a^10 - 3 * M^4 * a^12) * epsilon^2
+                        ) *
+                        r^4 -
+                        (20 * M^5 * a^12 * epsilon^2 - 3 * M^6 * a^10 * epsilon^3) * r^3
+                    ) *
+                    cos_theta^7 -
+                    (
+                        64 * M^5 * a^10 * epsilon^2 * r^5 + 138 * M * a^4 * r^17 -
+                        28 * a^4 * r^18 - 12 * (18 * M^2 * a^4 + 7 * a^6) * r^16 +
+                        2 *
+                        (52 * M^3 * a^4 + 108 * M * a^6 + 11 * M^2 * a^4 * epsilon) *
+                        r^15 +
+                        2 * (12 * M^2 * a^6 - 42 * a^8 - 29 * M^3 * a^4 * epsilon) * r^14 -
+                        4 * (60 * M^3 * a^6 + 3 * M * a^8 - M^2 * a^6 * epsilon) * r^13 +
+                        (
+                            360 * M^2 * a^8 - 28 * a^10 - 5 * M^4 * a^4 * epsilon^2 +
+                            4 * (14 * M^5 * a^4 + 33 * M^3 * a^6) * epsilon
+                        ) * r^12 -
+                        6 *
+                        (
+                            20 * M^3 * a^8 +
+                            20 * M * a^10 +
+                            (44 * M^4 * a^6 + 13 * M^2 * a^8) * epsilon
+                        ) *
+                        r^11 +
+                        (
+                            120 * M^2 * a^10 +
+                            (16 * M^6 * a^4 + 23 * M^4 * a^6) * epsilon^2 +
+                            2 * (16 * M^5 * a^6 + 105 * M^3 * a^8) * epsilon
+                        ) * r^10 -
+                        2 *
+                        (
+                            15 * M * a^12 + 24 * M^5 * a^6 * epsilon^2 -
+                            8 * (6 * M^4 * a^8 - 5 * M^2 * a^10) * epsilon
+                        ) *
+                        r^9 -
+                        2 *
+                        (
+                            (12 * M^6 * a^6 - 17 * M^4 * a^8) * epsilon^2 +
+                            4 * (18 * M^5 * a^8 + 5 * M^3 * a^10) * epsilon
+                        ) *
+                        r^8 +
+                        2 *
+                        (
+                            30 * M^5 * a^8 * epsilon^2 - 3 * M^6 * a^6 * epsilon^3 +
+                            2 * (48 * M^4 * a^10 - 5 * M^2 * a^12) * epsilon
+                        ) *
+                        r^7 -
+                        6 *
+                        (
+                            10 * M^3 * a^12 * epsilon +
+                            2 * M^7 * a^6 * epsilon^3 +
+                            (16 * M^6 * a^8 + M^4 * a^10) * epsilon^2
+                        ) *
+                        r^6 -
+                        12 *
+                        (
+                            2 * M^7 * a^8 * epsilon^3 -
+                            (2 * M^6 * a^10 - M^4 * a^12) * epsilon^2
+                        ) *
+                        r^4 -
+                        2 * (7 * M^5 * a^12 * epsilon^2 - 3 * M^6 * a^10 * epsilon^3) * r^3
+                    ) * cos_theta^5 +
+                    2 *
+                    (
+                        M^6 * a^10 * epsilon^3 * r^3 - 10 * M^7 * a^8 * epsilon^3 * r^4 -
+                        18 * M * a^2 * r^19 +
+                        4 * a^2 * r^20 +
+                        12 * (2 * M^2 * a^2 + a^4) * r^18 -
+                        2 * (4 * M^3 * a^2 + 12 * M * a^4 + M^2 * a^2 * epsilon) * r^17 -
+                        4 * (6 * M^2 * a^4 - 3 * a^6 - M^3 * a^2 * epsilon) * r^16 +
+                        2 *
+                        (
+                            24 * M^3 * a^4 +
+                            6 * M * a^6 +
+                            (2 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon
+                        ) *
+                        r^15 -
+                        2 *
+                        (
+                            36 * M^2 * a^6 - 2 * a^8 +
+                            (4 * M^5 * a^2 + 15 * M^3 * a^4) * epsilon
+                        ) *
+                        r^14 +
+                        (
+                            24 * M^3 * a^6 +
+                            24 * M * a^8 +
+                            (24 * M^4 * a^4 + 23 * M^2 * a^6) * epsilon
+                        ) * r^13 -
+                        (
+                            24 * M^2 * a^8 + 5 * M^4 * a^4 * epsilon^2 -
+                            8 * (2 * M^5 * a^4 - 3 * M^3 * a^6) * epsilon
+                        ) * r^12 +
+                        2 *
+                        (3 * M * a^10 - 2 * (18 * M^4 * a^6 - 5 * M^2 * a^8) * epsilon) *
+                        r^11 +
+                        (
+                            (16 * M^6 * a^4 - M^4 * a^6) * epsilon^2 +
+                            6 * (8 * M^5 * a^6 + 5 * M^3 * a^8) * epsilon
+                        ) * r^10 -
+                        (
+                            24 * M^5 * a^6 * epsilon^2 +
+                            (64 * M^4 * a^8 - 5 * M^2 * a^10) * epsilon
+                        ) * r^9 +
+                        2 *
+                        (
+                            10 * M^3 * a^10 * epsilon +
+                            (6 * M^6 * a^6 + 5 * M^4 * a^8) * epsilon^2
+                        ) *
+                        r^8 -
+                        (4 * M^5 * a^8 * epsilon^2 + 3 * M^6 * a^6 * epsilon^3) * r^7 -
+                        6 *
+                        (M^7 * a^6 * epsilon^3 + (4 * M^6 * a^8 - M^4 * a^10) * epsilon^2) *
+                        r^6 +
+                        2 * (7 * M^5 * a^10 * epsilon^2 - M^6 * a^8 * epsilon^3) * r^5
+                    ) *
+                    cos_theta^3 +
+                    (
+                        6 * M^7 * a^8 * epsilon^3 * r^4 +
+                        2 * M^6 * a^8 * epsilon^3 * r^5 +
+                        4 * M^7 * a^6 * epsilon^3 * r^6 +
+                        16 * M^5 * a^6 * epsilon^2 * r^9 - 4 * M * a^2 * r^19 -
+                        4 * M * r^21 +
+                        r^22 +
+                        (4 * M^2 + 3 * a^2) * r^20 - 3 * (4 * M^2 * a^2 - a^4) * r^18 +
+                        2 * (8 * M^3 * a^2 + 3 * M * a^4 + 2 * M^2 * a^2 * epsilon) * r^17 -
+                        (24 * M^2 * a^4 - a^6 + 8 * M^3 * a^2 * epsilon) * r^16 +
+                        2 *
+                        (
+                            4 * M^3 * a^4 + 4 * M * a^6 -
+                            (4 * M^4 * a^2 - 5 * M^2 * a^4) * epsilon
+                        ) *
+                        r^15 -
+                        2 * (4 * M^2 * a^6 - (8 * M^5 * a^2 + M^3 * a^4) * epsilon) * r^14 +
+                        2 * (M * a^8 - 4 * (6 * M^4 * a^4 - M^2 * a^6) * epsilon) * r^13 -
+                        2 * (16 * M^4 * a^6 - M^2 * a^8) * epsilon * r^11 +
+                        (
+                            5 * M^4 * a^4 * epsilon^2 +
+                            4 * (6 * M^5 * a^4 + 5 * M^3 * a^6) * epsilon
+                        ) * r^12 - 4 * (6 * M^6 * a^6 - M^4 * a^8) * epsilon^2 * r^8 +
+                        (
+                            10 * M^3 * a^8 * epsilon -
+                            (16 * M^6 * a^4 - 9 * M^4 * a^6) * epsilon^2
+                        ) * r^10 +
+                        2 * (7 * M^5 * a^8 * epsilon^2 + M^6 * a^6 * epsilon^3) * r^7
+                    ) * cos_theta
+                ) *
+                v_phi^2 *
+                sin_theta -
+                (
+                    (a^20 - 2 * M * a^18 * r + a^18 * r^2) * cos_theta^17 -
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r - 4 * a^18 * r^2 + 8 * M * a^16 * r^3 -
+                        4 * a^16 * r^4
+                    ) *
+                    cos_theta^15 +
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r + M^3 * a^14 * epsilon * r^2 -
+                        6 * M^2 * a^14 * epsilon * r^3 + 14 * a^16 * r^4 -
+                        28 * M * a^14 * r^5 + 14 * a^14 * r^6
+                    ) *
+                    cos_theta^13 +
+                    2 *
+                    (
+                        6 * M^2 * a^14 * epsilon * r^3 + 6 * M^3 * a^12 * epsilon * r^4 -
+                        15 * M^2 * a^12 * epsilon * r^5 + 28 * a^14 * r^6 -
+                        56 * M * a^12 * r^7 + 28 * a^12 * r^8
+                    ) *
+                    cos_theta^11 +
+                    (
+                        M^4 * a^12 * epsilon^2 * r^2 +
+                        M^4 * a^10 * epsilon^2 * r^4 +
+                        30 * M^2 * a^12 * epsilon * r^5 +
+                        30 * M^3 * a^10 * epsilon * r^6 - 40 * M^2 * a^10 * epsilon * r^7 +
+                        70 * a^12 * r^8 - 140 * M * a^10 * r^9 + 70 * a^10 * r^10
+                    ) * cos_theta^9 +
+                    2 *
+                    (
+                        2 * M^4 * a^10 * epsilon^2 * r^4 +
+                        2 * M^4 * a^8 * epsilon^2 * r^6 +
+                        20 * M^2 * a^10 * epsilon * r^7 +
+                        20 * M^3 * a^8 * epsilon * r^8 - 15 * M^2 * a^8 * epsilon * r^9 +
+                        28 * a^10 * r^10 - 56 * M * a^8 * r^11 + 28 * a^8 * r^12
+                    ) *
+                    cos_theta^7 +
+                    2 *
+                    (
+                        3 * M^4 * a^8 * epsilon^2 * r^6 +
+                        3 * M^4 * a^6 * epsilon^2 * r^8 +
+                        15 * M^2 * a^8 * epsilon * r^9 +
+                        15 * M^3 * a^6 * epsilon * r^10 - 6 * M^2 * a^6 * epsilon * r^11 +
+                        14 * a^8 * r^12 - 28 * M * a^6 * r^13 + 14 * a^6 * r^14
+                    ) *
+                    cos_theta^5 +
+                    2 *
+                    (
+                        2 * M^4 * a^6 * epsilon^2 * r^8 +
+                        2 * M^4 * a^4 * epsilon^2 * r^10 +
+                        6 * M^2 * a^6 * epsilon * r^11 +
+                        6 * M^3 * a^4 * epsilon * r^12 - M^2 * a^4 * epsilon * r^13 +
+                        4 * a^6 * r^14 - 8 * M * a^4 * r^15 + 4 * a^4 * r^16
+                    ) *
+                    cos_theta^3 +
+                    (
+                        M^4 * a^4 * epsilon^2 * r^10 +
+                        M^4 * a^2 * epsilon^2 * r^12 +
+                        2 * M^2 * a^4 * epsilon * r^13 +
+                        2 * M^3 * a^2 * epsilon * r^14 +
+                        a^4 * r^16 - 2 * M * a^2 * r^17 + a^2 * r^18
+                    ) * cos_theta
+                ) *
+                v_r^2 *
+                sin_theta -
+                4 *
+                (
+                    (
+                        M * a^19 * r - 4 * M^2 * a^17 * r^2 - 8 * M^2 * a^15 * r^4 -
+                        4 * M^2 * a^13 * r^6 +
+                        M * a^13 * r^7 +
+                        (4 * M^3 * a^13 + 3 * M * a^15) * r^5 +
+                        (4 * M^3 * a^15 + 3 * M * a^17) * r^3
+                    ) * cos_theta^13 -
+                    2 *
+                    (
+                        2 * M^3 * a^15 * epsilon * r^2 + 12 * M^2 * a^11 * r^8 -
+                        3 * M * a^11 * r^9 - 3 * (4 * M^3 * a^11 + 3 * M * a^13) * r^7 +
+                        2 * (12 * M^2 * a^13 + M^3 * a^11 * epsilon) * r^6 -
+                        3 *
+                        (4 * M^3 * a^13 + 3 * M * a^15 + 2 * M^4 * a^11 * epsilon) *
+                        r^5 +
+                        4 * (3 * M^2 * a^15 + (M^5 * a^11 + M^3 * a^13) * epsilon) * r^4 -
+                        3 * (M * a^17 + 2 * M^4 * a^13 * epsilon) * r^3
+                    ) *
+                    cos_theta^11 +
+                    (
+                        5 * M^3 * a^15 * epsilon * r^2 - 60 * M^2 * a^9 * r^10 +
+                        15 * M * a^9 * r^11 +
+                        15 * (4 * M^3 * a^9 + 3 * M * a^11) * r^9 -
+                        15 * (8 * M^2 * a^11 + M^3 * a^9 * epsilon) * r^8 +
+                        (60 * M^3 * a^11 + 45 * M * a^13 + 44 * M^4 * a^9 * epsilon) * r^7 -
+                        (60 * M^2 * a^13 + (28 * M^5 * a^9 + 25 * M^3 * a^11) * epsilon) *
+                        r^6 +
+                        (
+                            15 * M * a^15 +
+                            28 * M^4 * a^11 * epsilon +
+                            5 * M^5 * a^9 * epsilon^2
+                        ) * r^5 -
+                        (
+                            8 * M^6 * a^9 * epsilon^2 -
+                            (12 * M^5 * a^11 - 5 * M^3 * a^13) * epsilon
+                        ) * r^4 -
+                        (16 * M^4 * a^13 * epsilon - 5 * M^5 * a^11 * epsilon^2) * r^3
+                    ) * cos_theta^9 -
+                    2 *
+                    (
+                        6 * M^5 * a^11 * epsilon^2 * r^3 + 40 * M^2 * a^7 * r^12 -
+                        10 * M * a^7 * r^13 - 10 * (4 * M^3 * a^7 + 3 * M * a^9) * r^11 +
+                        10 * (8 * M^2 * a^9 + M^3 * a^7 * epsilon) * r^10 -
+                        2 *
+                        (20 * M^3 * a^9 + 15 * M * a^11 + 14 * M^4 * a^7 * epsilon) *
+                        r^9 +
+                        2 *
+                        (20 * M^2 * a^11 + (8 * M^5 * a^7 + 5 * M^3 * a^9) * epsilon) *
+                        r^8 -
+                        2 *
+                        (
+                            5 * M * a^13 - 2 * M^4 * a^9 * epsilon +
+                            2 * M^5 * a^7 * epsilon^2
+                        ) *
+                        r^7 +
+                        2 *
+                        (
+                            3 * M^6 * a^7 * epsilon^2 -
+                            (12 * M^5 * a^9 + 5 * M^3 * a^11) * epsilon
+                        ) *
+                        r^6 +
+                        2 * (16 * M^4 * a^11 * epsilon + M^5 * a^9 * epsilon^2) * r^5 -
+                        (
+                            10 * M^3 * a^13 * epsilon + 10 * M^6 * a^9 * epsilon^2 -
+                            M^7 * a^7 * epsilon^3
+                        ) * r^4
+                    ) *
+                    cos_theta^7 +
+                    (
+                        7 * M^5 * a^11 * epsilon^2 * r^3 -
+                        15 * M^5 * a^9 * epsilon^2 * r^5 - 60 * M^2 * a^5 * r^14 +
+                        15 * M * a^5 * r^15 +
+                        15 * (4 * M^3 * a^5 + 3 * M * a^7) * r^13 -
+                        10 * (12 * M^2 * a^7 + M^3 * a^5 * epsilon) * r^12 +
+                        3 *
+                        (20 * M^3 * a^7 + 15 * M * a^9 + 8 * M^4 * a^5 * epsilon) *
+                        r^11 -
+                        2 *
+                        (30 * M^2 * a^9 + (4 * M^5 * a^5 - 5 * M^3 * a^7) * epsilon) *
+                        r^10 +
+                        2 * (36 * M^5 * a^7 + 25 * M^3 * a^9) * epsilon * r^8 +
+                        (15 * M * a^11 - 72 * M^4 * a^7 * epsilon + M^5 * a^5 * epsilon^2) *
+                        r^9 -
+                        3 * (32 * M^4 * a^9 * epsilon + 7 * M^5 * a^7 * epsilon^2) * r^7 +
+                        (
+                            30 * M^3 * a^11 * epsilon +
+                            36 * M^6 * a^7 * epsilon^2 +
+                            M^7 * a^5 * epsilon^3
+                        ) * r^6 -
+                        (12 * M^6 * a^9 * epsilon^2 - 7 * M^7 * a^7 * epsilon^3) * r^4
+                    ) * cos_theta^5 -
+                    2 *
+                    (
+                        4 * M^7 * a^7 * epsilon^3 * r^4 - 7 * M^5 * a^9 * epsilon^2 * r^5 -
+                        3 * M^5 * a^7 * epsilon^2 * r^7 +
+                        24 * M^2 * a^5 * r^14 +
+                        12 * M^2 * a^3 * r^16 - 3 * M * a^3 * r^17 -
+                        3 * (4 * M^3 * a^3 + 3 * M * a^5) * r^15 -
+                        (12 * M^3 * a^5 + 9 * M * a^7 - 2 * M^4 * a^3 * epsilon) * r^13 +
+                        2 *
+                        (6 * M^2 * a^7 - (2 * M^5 * a^3 + 5 * M^3 * a^5) * epsilon) *
+                        r^12 -
+                        (3 * M * a^9 - 34 * M^4 * a^5 * epsilon - M^5 * a^3 * epsilon^2) *
+                        r^11 -
+                        2 *
+                        (
+                            M^6 * a^3 * epsilon^2 +
+                            2 * (6 * M^5 * a^5 + 5 * M^3 * a^7) * epsilon
+                        ) *
+                        r^10 +
+                        (32 * M^4 * a^7 * epsilon + 5 * M^5 * a^5 * epsilon^2) * r^9 -
+                        2 * (5 * M^3 * a^9 * epsilon + 3 * M^6 * a^5 * epsilon^2) * r^8 +
+                        (12 * M^6 * a^7 * epsilon^2 + M^7 * a^5 * epsilon^3) * r^6
+                    ) *
+                    cos_theta^3 +
+                    (
+                        3 * M^7 * a^7 * epsilon^3 * r^4 +
+                        M^7 * a^5 * epsilon^3 * r^6 +
+                        7 * M^5 * a^7 * epsilon^2 * r^7 - 12 * M^6 * a^5 * epsilon^2 * r^8 +
+                        9 * M^5 * a^5 * epsilon^2 * r^9 - 4 * M^2 * a * r^18 +
+                        M * a * r^19 +
+                        (4 * M^3 * a + 3 * M * a^3) * r^17 -
+                        (8 * M^2 * a^3 - M^3 * a * epsilon) * r^16 +
+                        (4 * M^3 * a^3 + 3 * M * a^5 - 4 * M^4 * a * epsilon) * r^15 -
+                        (4 * M^2 * a^5 - (4 * M^5 * a + 7 * M^3 * a^3) * epsilon) * r^14 +
+                        (12 * M^5 * a^3 + 11 * M^3 * a^5) * epsilon * r^12 +
+                        (M * a^7 - 20 * M^4 * a^3 * epsilon) * r^13 -
+                        2 * (8 * M^4 * a^5 * epsilon - M^5 * a^3 * epsilon^2) * r^11 +
+                        (5 * M^3 * a^7 * epsilon - 4 * M^6 * a^3 * epsilon^2) * r^10
+                    ) * cos_theta
+                ) *
+                v_phi *
+                v_t *
+                sin_theta +
+                2 *
+                (
+                    (
+                        M * a^18 * r - 4 * M^2 * a^16 * r^2 - 4 * M^2 * a^14 * r^4 +
+                        M * a^14 * r^5 +
+                        2 * (2 * M^3 * a^14 + M * a^16) * r^3
+                    ) * cos_theta^13 -
+                    (
+                        M^2 * a^16 * epsilon * r - 2 * M^3 * a^14 * epsilon * r^2 +
+                        24 * M^2 * a^12 * r^6 - 6 * M * a^12 * r^7 -
+                        (24 * M^3 * a^12 + 12 * M * a^14 - M^2 * a^12 * epsilon) * r^5 +
+                        2 * (12 * M^2 * a^14 - M^3 * a^12 * epsilon) * r^4 -
+                        2 * (3 * M * a^16 - M^2 * a^14 * epsilon) * r^3
+                    ) * cos_theta^11 -
+                    (
+                        60 * M^2 * a^10 * r^8 - 15 * M * a^10 * r^9 -
+                        5 * (12 * M^3 * a^10 + 6 * M * a^12 - M^2 * a^10 * epsilon) * r^7 +
+                        15 * (4 * M^2 * a^12 - M^3 * a^10 * epsilon) * r^6 -
+                        (15 * M * a^14 - 2 * (8 * M^4 * a^10 + 5 * M^2 * a^12) * epsilon) *
+                        r^5 -
+                        2 *
+                        (
+                            M^4 * a^10 * epsilon^2 +
+                            2 * (3 * M^5 * a^10 + 5 * M^3 * a^12) * epsilon
+                        ) *
+                        r^4 +
+                        (
+                            3 * M^5 * a^10 * epsilon^2 +
+                            (16 * M^4 * a^12 + 5 * M^2 * a^14) * epsilon
+                        ) * r^3 -
+                        (5 * M^3 * a^14 * epsilon + 2 * M^4 * a^12 * epsilon^2) * r^2
+                    ) * cos_theta^9 -
+                    (
+                        2 * M^4 * a^12 * epsilon^2 * r^2 + 80 * M^2 * a^8 * r^10 -
+                        20 * M * a^8 * r^11 -
+                        10 * (8 * M^3 * a^8 + 4 * M * a^10 - M^2 * a^8 * epsilon) * r^9 +
+                        40 * (2 * M^2 * a^10 - M^3 * a^8 * epsilon) * r^8 -
+                        4 *
+                        (5 * M * a^12 - (16 * M^4 * a^8 + 5 * M^2 * a^10) * epsilon) *
+                        r^7 -
+                        6 *
+                        (
+                            M^4 * a^8 * epsilon^2 +
+                            2 * (4 * M^5 * a^8 + 5 * M^3 * a^10) * epsilon
+                        ) *
+                        r^6 +
+                        2 *
+                        (
+                            8 * M^5 * a^8 * epsilon^2 +
+                            (32 * M^4 * a^10 + 5 * M^2 * a^12) * epsilon
+                        ) *
+                        r^5 -
+                        4 *
+                        (
+                            5 * M^3 * a^12 * epsilon +
+                            (3 * M^6 * a^8 + M^4 * a^10) * epsilon^2
+                        ) *
+                        r^4 + (4 * M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3) * r^3
+                    ) * cos_theta^7 -
+                    (
+                        60 * M^2 * a^6 * r^12 - 15 * M * a^6 * r^13 -
+                        10 * (6 * M^3 * a^6 + 3 * M * a^8 - M^2 * a^6 * epsilon) * r^11 +
+                        10 * (6 * M^2 * a^8 - 5 * M^3 * a^6 * epsilon) * r^10 -
+                        (15 * M * a^10 - 4 * (24 * M^4 * a^6 + 5 * M^2 * a^8) * epsilon) *
+                        r^9 -
+                        2 *
+                        (
+                            3 * M^4 * a^6 * epsilon^2 +
+                            4 * (9 * M^5 * a^6 + 10 * M^3 * a^8) * epsilon
+                        ) *
+                        r^8 +
+                        (
+                            23 * M^5 * a^6 * epsilon^2 +
+                            2 * (48 * M^4 * a^8 + 5 * M^2 * a^10) * epsilon
+                        ) * r^7 -
+                        6 * (5 * M^3 * a^10 * epsilon + 4 * M^6 * a^6 * epsilon^2) * r^6 -
+                        (2 * M^5 * a^8 * epsilon^2 - M^6 * a^6 * epsilon^3) * r^5 -
+                        3 *
+                        (
+                            M^7 * a^6 * epsilon^3 -
+                            2 * (2 * M^6 * a^8 + M^4 * a^10) * epsilon^2
+                        ) *
+                        r^4 -
+                        (7 * M^5 * a^10 * epsilon^2 + 2 * M^6 * a^8 * epsilon^3) * r^3
+                    ) * cos_theta^5 -
+                    (
+                        M^6 * a^8 * epsilon^3 * r^3 + 6 * M^7 * a^6 * epsilon^3 * r^4 -
+                        16 * M^5 * a^6 * epsilon^2 * r^7 + 24 * M^2 * a^4 * r^14 -
+                        6 * M * a^4 * r^15 -
+                        (24 * M^3 * a^4 + 12 * M * a^6 - 5 * M^2 * a^4 * epsilon) * r^13 +
+                        6 * (4 * M^2 * a^6 - 5 * M^3 * a^4 * epsilon) * r^12 -
+                        2 *
+                        (3 * M * a^8 - (32 * M^4 * a^4 + 5 * M^2 * a^6) * epsilon) *
+                        r^11 -
+                        2 *
+                        (
+                            M^4 * a^4 * epsilon^2 +
+                            (24 * M^5 * a^4 + 25 * M^3 * a^6) * epsilon
+                        ) *
+                        r^10 +
+                        (
+                            10 * M^5 * a^4 * epsilon^2 +
+                            (64 * M^4 * a^6 + 5 * M^2 * a^8) * epsilon
+                        ) * r^9 +
+                        6 * (4 * M^6 * a^6 + M^4 * a^8) * epsilon^2 * r^6 -
+                        4 *
+                        (
+                            5 * M^3 * a^8 * epsilon +
+                            (3 * M^6 * a^4 - M^4 * a^6) * epsilon^2
+                        ) *
+                        r^8 - 2 * (7 * M^5 * a^8 * epsilon^2 + M^6 * a^6 * epsilon^3) * r^5
+                    ) * cos_theta^3 +
+                    (
+                        3 * M^7 * a^6 * epsilon^3 * r^4 - M^6 * a^6 * epsilon^3 * r^5 +
+                        7 * M^5 * a^6 * epsilon^2 * r^7 +
+                        10 * M^5 * a^4 * epsilon^2 * r^9 - 4 * M^2 * a^2 * r^16 +
+                        M * a^2 * r^17 +
+                        (4 * M^3 * a^2 + 2 * M * a^4 - M^2 * a^2 * epsilon) * r^15 -
+                        (4 * M^2 * a^4 - 7 * M^3 * a^2 * epsilon) * r^14 +
+                        12 * (M^5 * a^2 + M^3 * a^4) * epsilon * r^12 +
+                        (M * a^6 - 2 * (8 * M^4 * a^2 + M^2 * a^4) * epsilon) * r^13 -
+                        (16 * M^4 * a^4 + M^2 * a^6) * epsilon * r^11 -
+                        2 * (6 * M^6 * a^4 + M^4 * a^6) * epsilon^2 * r^8 +
+                        (5 * M^3 * a^6 * epsilon - 2 * M^4 * a^4 * epsilon^2) * r^10
+                    ) * cos_theta
+                ) *
+                v_t^2 *
+                sin_theta +
+                (
+                    (
+                        a^22 - 4 * M * a^20 * r - 4 * M * a^18 * r^3 +
+                        a^18 * r^4 +
+                        2 * (2 * M^2 * a^18 + a^20) * r^2
+                    ) * cos_theta^17 -
+                    2 *
+                    (
+                        M^2 * a^18 * epsilon * r + 16 * M * a^16 * r^5 - 4 * a^16 * r^6 -
+                        8 * (2 * M^2 * a^16 + a^18) * r^4 +
+                        (16 * M * a^18 + M^2 * a^16 * epsilon) * r^3 -
+                        2 * (2 * a^20 + M^3 * a^16 * epsilon) * r^2
+                    ) *
+                    cos_theta^15 +
+                    (
+                        2 * M^2 * a^18 * epsilon * r - 10 * M^2 * a^16 * epsilon * r^3 -
+                        112 * M * a^14 * r^7 +
+                        28 * a^14 * r^8 +
+                        56 * (2 * M^2 * a^14 + a^16) * r^6 -
+                        4 * (28 * M * a^16 + 3 * M^2 * a^14 * epsilon) * r^5 +
+                        4 * (7 * a^18 + 6 * M^3 * a^14 * epsilon) * r^4 -
+                        (4 * M^3 * a^16 * epsilon - M^4 * a^14 * epsilon^2) * r^2
+                    ) * cos_theta^13 -
+                    2 *
+                    (
+                        M^4 * a^14 * epsilon^2 * r^2 - 6 * M^2 * a^16 * epsilon * r^3 +
+                        9 * M^2 * a^14 * epsilon * r^5 +
+                        112 * M * a^12 * r^9 - 28 * a^12 * r^10 -
+                        56 * (2 * M^2 * a^12 + a^14) * r^8 +
+                        (112 * M * a^14 + 15 * M^2 * a^12 * epsilon) * r^7 -
+                        2 * (14 * a^16 + 15 * M^3 * a^12 * epsilon) * r^6 +
+                        2 * (6 * M^3 * a^14 * epsilon - M^4 * a^12 * epsilon^2) * r^4
+                    ) *
+                    cos_theta^11 +
+                    (
+                        M^4 * a^14 * epsilon^2 * r^2 - 8 * M^4 * a^12 * epsilon^2 * r^4 +
+                        30 * M^2 * a^14 * epsilon * r^5 - 10 * M^2 * a^12 * epsilon * r^7 -
+                        280 * M * a^10 * r^11 +
+                        70 * a^10 * r^12 +
+                        140 * (2 * M^2 * a^10 + a^12) * r^10 -
+                        40 * (7 * M * a^12 + M^2 * a^10 * epsilon) * r^9 +
+                        10 * (7 * a^14 + 8 * M^3 * a^10 * epsilon) * r^8 -
+                        6 * (10 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * r^6
+                    ) * cos_theta^9 +
+                    2 *
+                    (
+                        2 * M^4 * a^12 * epsilon^2 * r^4 -
+                        6 * M^4 * a^10 * epsilon^2 * r^6 +
+                        20 * M^2 * a^12 * epsilon * r^7 +
+                        5 * M^2 * a^10 * epsilon * r^9 - 112 * M * a^8 * r^13 +
+                        28 * a^8 * r^14 +
+                        56 * (2 * M^2 * a^8 + a^10) * r^12 -
+                        (112 * M * a^10 + 15 * M^2 * a^8 * epsilon) * r^11 +
+                        2 * (14 * a^12 + 15 * M^3 * a^8 * epsilon) * r^10 -
+                        2 * (20 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * r^8
+                    ) *
+                    cos_theta^7 +
+                    (
+                        6 * M^4 * a^10 * epsilon^2 * r^6 - 8 * M^4 * a^8 * epsilon^2 * r^8 +
+                        30 * M^2 * a^10 * epsilon * r^9 +
+                        18 * M^2 * a^8 * epsilon * r^11 - 112 * M * a^6 * r^15 +
+                        28 * a^6 * r^16 +
+                        56 * (2 * M^2 * a^6 + a^8) * r^14 -
+                        4 * (28 * M * a^8 + 3 * M^2 * a^6 * epsilon) * r^13 +
+                        4 * (7 * a^10 + 6 * M^3 * a^6 * epsilon) * r^12 -
+                        (60 * M^3 * a^8 * epsilon - M^4 * a^6 * epsilon^2) * r^10
+                    ) * cos_theta^5 +
+                    2 *
+                    (
+                        2 * M^4 * a^8 * epsilon^2 * r^8 - M^4 * a^6 * epsilon^2 * r^10 +
+                        6 * M^2 * a^8 * epsilon * r^11 - 12 * M^3 * a^6 * epsilon * r^12 +
+                        5 * M^2 * a^6 * epsilon * r^13 - 16 * M * a^4 * r^17 +
+                        4 * a^4 * r^18 +
+                        8 * (2 * M^2 * a^4 + a^6) * r^16 -
+                        (16 * M * a^6 + M^2 * a^4 * epsilon) * r^15 +
+                        2 * (2 * a^8 + M^3 * a^4 * epsilon) * r^14
+                    ) *
+                    cos_theta^3 +
+                    (
+                        M^4 * a^6 * epsilon^2 * r^10 + 2 * M^2 * a^6 * epsilon * r^13 -
+                        4 * M^3 * a^4 * epsilon * r^14 +
+                        2 * M^2 * a^4 * epsilon * r^15 +
+                        a^6 * r^16 - 4 * M * a^4 * r^17 - 4 * M * a^2 * r^19 +
+                        a^2 * r^20 +
+                        2 * (2 * M^2 * a^2 + a^4) * r^18
+                    ) * cos_theta
+                ) *
+                v_theta^2 *
+                sin_theta -
+                2 *
+                (
+                    M^4 * a^4 * epsilon^2 * r^11 + 2 * M^2 * a^4 * epsilon * r^14 -
+                    4 * M^3 * a^2 * epsilon * r^15 +
+                    2 * M^2 * a^2 * epsilon * r^16 +
+                    a^4 * r^17 - 4 * M * a^2 * r^18 - 4 * M * r^20 +
+                    r^21 +
+                    2 * (2 * M^2 + a^2) * r^19 +
+                    (
+                        a^20 * r - 4 * M * a^18 * r^2 - 4 * M * a^16 * r^4 +
+                        a^16 * r^5 +
+                        2 * (2 * M^2 * a^16 + a^18) * r^3
+                    ) * cos_theta^16 -
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r^2 + 16 * M * a^14 * r^6 - 4 * a^14 * r^7 -
+                        8 * (2 * M^2 * a^14 + a^16) * r^5 +
+                        (16 * M * a^16 + M^2 * a^14 * epsilon) * r^4 -
+                        2 * (2 * a^18 + M^3 * a^14 * epsilon) * r^3
+                    ) *
+                    cos_theta^14 +
+                    (
+                        2 * M^2 * a^16 * epsilon * r^2 - 10 * M^2 * a^14 * epsilon * r^4 -
+                        112 * M * a^12 * r^8 +
+                        28 * a^12 * r^9 +
+                        56 * (2 * M^2 * a^12 + a^14) * r^7 -
+                        4 * (28 * M * a^14 + 3 * M^2 * a^12 * epsilon) * r^6 +
+                        4 * (7 * a^16 + 6 * M^3 * a^12 * epsilon) * r^5 -
+                        (4 * M^3 * a^14 * epsilon - M^4 * a^12 * epsilon^2) * r^3
+                    ) * cos_theta^12 -
+                    2 *
+                    (
+                        M^4 * a^12 * epsilon^2 * r^3 - 6 * M^2 * a^14 * epsilon * r^4 +
+                        9 * M^2 * a^12 * epsilon * r^6 +
+                        112 * M * a^10 * r^10 - 28 * a^10 * r^11 -
+                        56 * (2 * M^2 * a^10 + a^12) * r^9 +
+                        (112 * M * a^12 + 15 * M^2 * a^10 * epsilon) * r^8 -
+                        2 * (14 * a^14 + 15 * M^3 * a^10 * epsilon) * r^7 +
+                        2 * (6 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * r^5
+                    ) *
+                    cos_theta^10 +
+                    (
+                        M^4 * a^12 * epsilon^2 * r^3 - 8 * M^4 * a^10 * epsilon^2 * r^5 +
+                        30 * M^2 * a^12 * epsilon * r^6 - 10 * M^2 * a^10 * epsilon * r^8 -
+                        280 * M * a^8 * r^12 +
+                        70 * a^8 * r^13 +
+                        140 * (2 * M^2 * a^8 + a^10) * r^11 -
+                        40 * (7 * M * a^10 + M^2 * a^8 * epsilon) * r^10 +
+                        10 * (7 * a^12 + 8 * M^3 * a^8 * epsilon) * r^9 -
+                        6 * (10 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * r^7
+                    ) * cos_theta^8 +
+                    2 *
+                    (
+                        2 * M^4 * a^10 * epsilon^2 * r^5 - 6 * M^4 * a^8 * epsilon^2 * r^7 +
+                        20 * M^2 * a^10 * epsilon * r^8 +
+                        5 * M^2 * a^8 * epsilon * r^10 - 112 * M * a^6 * r^14 +
+                        28 * a^6 * r^15 +
+                        56 * (2 * M^2 * a^6 + a^8) * r^13 -
+                        (112 * M * a^8 + 15 * M^2 * a^6 * epsilon) * r^12 +
+                        2 * (14 * a^10 + 15 * M^3 * a^6 * epsilon) * r^11 -
+                        2 * (20 * M^3 * a^8 * epsilon - M^4 * a^6 * epsilon^2) * r^9
+                    ) *
+                    cos_theta^6 +
+                    (
+                        6 * M^4 * a^8 * epsilon^2 * r^7 - 8 * M^4 * a^6 * epsilon^2 * r^9 +
+                        30 * M^2 * a^8 * epsilon * r^10 +
+                        18 * M^2 * a^6 * epsilon * r^12 - 112 * M * a^4 * r^16 +
+                        28 * a^4 * r^17 +
+                        56 * (2 * M^2 * a^4 + a^6) * r^15 -
+                        4 * (28 * M * a^6 + 3 * M^2 * a^4 * epsilon) * r^14 +
+                        4 * (7 * a^8 + 6 * M^3 * a^4 * epsilon) * r^13 -
+                        (60 * M^3 * a^6 * epsilon - M^4 * a^4 * epsilon^2) * r^11
+                    ) * cos_theta^4 +
+                    2 *
+                    (
+                        2 * M^4 * a^6 * epsilon^2 * r^9 - M^4 * a^4 * epsilon^2 * r^11 +
+                        6 * M^2 * a^6 * epsilon * r^12 - 12 * M^3 * a^4 * epsilon * r^13 +
+                        5 * M^2 * a^4 * epsilon * r^14 - 16 * M * a^2 * r^18 +
+                        4 * a^2 * r^19 +
+                        8 * (2 * M^2 * a^2 + a^4) * r^17 -
+                        (16 * M * a^4 + M^2 * a^2 * epsilon) * r^16 +
+                        2 * (2 * a^6 + M^3 * a^2 * epsilon) * r^15
+                    ) *
+                    cos_theta^2
+                ) *
+                v_r *
+                v_theta
+            ) / (
+                a^4 * r^18 - 4 * M * a^2 * r^19 - 4 * M * r^21 +
+                r^22 +
+                2 * (2 * M^2 + a^2) * r^20 +
+                (
+                    a^22 - 4 * M * a^20 * r - 4 * M * a^18 * r^3 +
+                    a^18 * r^4 +
+                    2 * (2 * M^2 * a^18 + a^20) * r^2
+                ) * cos_theta^18 +
+                9 *
+                (
+                    a^20 * r^2 - 4 * M * a^18 * r^3 - 4 * M * a^16 * r^5 +
+                    a^16 * r^6 +
+                    2 * (2 * M^2 * a^16 + a^18) * r^4
+                ) *
+                cos_theta^16 +
+                36 *
+                (
+                    a^18 * r^4 - 4 * M * a^16 * r^5 - 4 * M * a^14 * r^7 +
+                    a^14 * r^8 +
+                    2 * (2 * M^2 * a^14 + a^16) * r^6
+                ) *
+                cos_theta^14 +
+                84 *
+                (
+                    a^16 * r^6 - 4 * M * a^14 * r^7 - 4 * M * a^12 * r^9 +
+                    a^12 * r^10 +
+                    2 * (2 * M^2 * a^12 + a^14) * r^8
+                ) *
+                cos_theta^12 +
+                126 *
+                (
+                    a^14 * r^8 - 4 * M * a^12 * r^9 - 4 * M * a^10 * r^11 +
+                    a^10 * r^12 +
+                    2 * (2 * M^2 * a^10 + a^12) * r^10
+                ) *
+                cos_theta^10 +
+                126 *
+                (
+                    a^12 * r^10 - 4 * M * a^10 * r^11 - 4 * M * a^8 * r^13 +
+                    a^8 * r^14 +
+                    2 * (2 * M^2 * a^8 + a^10) * r^12
+                ) *
+                cos_theta^8 +
+                84 *
+                (
+                    a^10 * r^12 - 4 * M * a^8 * r^13 - 4 * M * a^6 * r^15 +
+                    a^6 * r^16 +
+                    2 * (2 * M^2 * a^6 + a^8) * r^14
+                ) *
+                cos_theta^6 +
+                36 *
+                (
+                    a^8 * r^14 - 4 * M * a^6 * r^15 - 4 * M * a^4 * r^17 +
+                    a^4 * r^18 +
+                    2 * (2 * M^2 * a^4 + a^6) * r^16
+                ) *
+                cos_theta^4 +
+                (
+                    M^4 * a^14 * epsilon^2 * r^2 * cos_theta^10 +
+                    5 * M^4 * a^12 * epsilon^2 * r^4 * cos_theta^8 +
+                    10 * M^4 * a^10 * epsilon^2 * r^6 * cos_theta^6 +
+                    10 * M^4 * a^8 * epsilon^2 * r^8 * cos_theta^4 +
+                    5 * M^4 * a^6 * epsilon^2 * r^10 * cos_theta^2 +
+                    M^4 * a^4 * epsilon^2 * r^12
+                ) * sin_theta^4 +
+                9 *
+                (
+                    a^6 * r^16 - 4 * M * a^4 * r^17 - 4 * M * a^2 * r^19 +
+                    a^2 * r^20 +
+                    2 * (2 * M^2 * a^2 + a^4) * r^18
+                ) *
+                cos_theta^2 +
+                2 *
+                (
+                    M^2 * a^4 * epsilon * r^15 - 2 * M^3 * a^2 * epsilon * r^16 +
+                    M^2 * a^2 * epsilon * r^17 +
+                    (
+                        M^2 * a^18 * epsilon * r - 2 * M^3 * a^16 * epsilon * r^2 +
+                        M^2 * a^16 * epsilon * r^3
+                    ) * cos_theta^14 +
+                    7 *
+                    (
+                        M^2 * a^16 * epsilon * r^3 - 2 * M^3 * a^14 * epsilon * r^4 +
+                        M^2 * a^14 * epsilon * r^5
+                    ) *
+                    cos_theta^12 +
+                    21 *
+                    (
+                        M^2 * a^14 * epsilon * r^5 - 2 * M^3 * a^12 * epsilon * r^6 +
+                        M^2 * a^12 * epsilon * r^7
+                    ) *
+                    cos_theta^10 +
+                    35 *
+                    (
+                        M^2 * a^12 * epsilon * r^7 - 2 * M^3 * a^10 * epsilon * r^8 +
+                        M^2 * a^10 * epsilon * r^9
+                    ) *
+                    cos_theta^8 +
+                    35 *
+                    (
+                        M^2 * a^10 * epsilon * r^9 - 2 * M^3 * a^8 * epsilon * r^10 +
+                        M^2 * a^8 * epsilon * r^11
+                    ) *
+                    cos_theta^6 +
+                    21 *
+                    (
+                        M^2 * a^8 * epsilon * r^11 - 2 * M^3 * a^6 * epsilon * r^12 +
+                        M^2 * a^6 * epsilon * r^13
+                    ) *
+                    cos_theta^4 +
+                    7 *
+                    (
+                        M^2 * a^6 * epsilon * r^13 - 2 * M^3 * a^4 * epsilon * r^14 +
+                        M^2 * a^4 * epsilon * r^15
+                    ) *
+                    cos_theta^2
+                ) *
+                sin_theta^2
+            )
+        out4 =
+            (
+                2 *
+                (
+                    M * a^7 * cos_theta^6 + M * a^5 * r^2 * cos_theta^4 -
+                    M^3 * a * epsilon * r^3 - M * a * r^6 +
+                    (M^3 * a^3 * epsilon * r - M * a^3 * r^4) * cos_theta^2
+                ) *
+                v_r *
+                v_t *
+                sin_theta -
+                (
+                    (
+                        2 * M * a^8 * cos_theta^6 - 2 * M^3 * a^2 * epsilon * r^3 -
+                        3 * M^2 * a^2 * epsilon * r^4 - 2 * M * a^2 * r^6 +
+                        (M^2 * a^6 * epsilon + 2 * M * a^6 * r^2) * cos_theta^4 +
+                        2 *
+                        (
+                            M^3 * a^4 * epsilon * r - M^2 * a^4 * epsilon * r^2 -
+                            M * a^4 * r^4
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^3 +
+                    2 *
+                    (
+                        a^8 * r * cos_theta^8 - 2 * M * r^8 + r^9 -
+                        2 * (M * a^6 * r^2 - 2 * a^6 * r^3) * cos_theta^6 -
+                        6 * (M * a^4 * r^4 - a^4 * r^5) * cos_theta^4 -
+                        2 * (3 * M * a^2 * r^6 - 2 * a^2 * r^7) * cos_theta^2
+                    ) *
+                    sin_theta
+                ) *
+                v_phi *
+                v_r -
+                2 *
+                (
+                    (
+                        (a^10 - 2 * M * a^8 * r + a^8 * r^2) * cos_theta^9 -
+                        2 *
+                        (
+                            M * a^8 * r + 5 * M * a^6 * r^3 - 2 * a^6 * r^4 -
+                            2 * (M^2 * a^6 + a^8) * r^2
+                        ) *
+                        cos_theta^7 -
+                        2 *
+                        (
+                            8 * M * a^4 * r^5 - 3 * a^4 * r^6 -
+                            (4 * M^2 * a^4 + 3 * a^6) * r^4 +
+                            (M * a^6 + M^2 * a^4 * epsilon) * r^3 +
+                            (2 * M^2 * a^6 - M^3 * a^4 * epsilon) * r^2 -
+                            (M * a^8 - M^2 * a^6 * epsilon) * r
+                        ) *
+                        cos_theta^5 +
+                        2 *
+                        (
+                            M^2 * a^6 * epsilon * r - 2 * M^3 * a^4 * epsilon * r^2 -
+                            4 * M^2 * a^4 * r^4 - 5 * M * a^2 * r^7 +
+                            2 * a^2 * r^8 +
+                            2 * (M^2 * a^2 + a^4) * r^6 +
+                            (M * a^4 - M^2 * a^2 * epsilon) * r^5 +
+                            2 * (M * a^6 + M^4 * a^2 * epsilon) * r^3
+                        ) *
+                        cos_theta^3 +
+                        (
+                            2 * M^3 * a^4 * epsilon * r^2 - 4 * M^2 * a^2 * r^6 +
+                            2 * M * a^2 * r^7 +
+                            a^2 * r^8 - 2 * M * r^9 +
+                            r^10 +
+                            2 * (M * a^4 + M^2 * a^2 * epsilon) * r^5 -
+                            2 * (2 * M^4 * a^2 - M^2 * a^4) * epsilon * r^3
+                        ) * cos_theta
+                    ) * v_phi -
+                    2 *
+                    (
+                        (M * a^7 * r - 2 * M^2 * a^5 * r^2 + M * a^5 * r^3) * cos_theta^5 +
+                        2 *
+                        (M * a^5 * r^3 - 2 * M^2 * a^3 * r^4 + M * a^3 * r^5) *
+                        cos_theta^3 +
+                        (
+                            M^3 * a^3 * epsilon * r^2 - 2 * M^4 * a * epsilon * r^3 +
+                            M^3 * a * epsilon * r^4 +
+                            M * a^3 * r^5 - 2 * M^2 * a * r^6 + M * a * r^7
+                        ) * cos_theta
+                    ) *
+                    v_t
+                ) *
+                v_theta
+            ) / (
+                (
+                    M^2 * a^2 * epsilon * r^5 + a^2 * r^8 - 2 * M * r^9 +
+                    r^10 +
+                    (a^10 - 2 * M * a^8 * r + a^8 * r^2) * cos_theta^8 -
+                    (
+                        M^2 * a^6 * epsilon * r - 4 * a^8 * r^2 + 8 * M * a^6 * r^3 -
+                        4 * a^6 * r^4
+                    ) * cos_theta^6 +
+                    (
+                        M^2 * a^6 * epsilon * r - 2 * M^2 * a^4 * epsilon * r^3 +
+                        6 * a^6 * r^4 - 12 * M * a^4 * r^5 + 6 * a^4 * r^6
+                    ) * cos_theta^4 +
+                    (
+                        2 * M^2 * a^4 * epsilon * r^3 - M^2 * a^2 * epsilon * r^5 +
+                        4 * a^4 * r^6 - 8 * M * a^2 * r^7 + 4 * a^2 * r^8
+                    ) * cos_theta^2
+                ) * sin_theta
+            )
+
+        (out1, out2, out3, out4)
+    end
+end
+
+@inline function constrain(μ, u, v, M, a, epsilon)
+    ComputedGeodesicEquations.@let_unpack u v begin
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        (
+            2 *
+            (
+                (
+                    M^3 * a^7 * epsilon * r^2 * cos_theta^4 +
+                    2 * M^3 * a^5 * epsilon * r^4 * cos_theta^2 +
+                    M^5 * a^3 * epsilon^2 * r^3 +
+                    M^3 * a^3 * epsilon * r^6
+                ) * sin_theta^4 +
+                (
+                    M^3 * a^3 * epsilon * r^6 - 2 * M^4 * a * epsilon * r^7 +
+                    M^3 * a * epsilon * r^8 +
+                    M * a^3 * r^9 - 2 * M^2 * a * r^10 +
+                    M * a * r^11 +
+                    (M * a^11 * r - 2 * M^2 * a^9 * r^2 + M * a^9 * r^3) * cos_theta^8 +
+                    4 *
+                    (M * a^9 * r^3 - 2 * M^2 * a^7 * r^4 + M * a^7 * r^5) *
+                    cos_theta^6 +
+                    (
+                        M^3 * a^7 * epsilon * r^2 - 2 * M^4 * a^5 * epsilon * r^3 +
+                        M^3 * a^5 * epsilon * r^4 +
+                        6 * M * a^7 * r^5 - 12 * M^2 * a^5 * r^6 + 6 * M * a^5 * r^7
+                    ) * cos_theta^4 +
+                    2 *
+                    (
+                        M^3 * a^5 * epsilon * r^4 - 2 * M^4 * a^3 * epsilon * r^5 +
+                        M^3 * a^3 * epsilon * r^6 +
+                        2 * M * a^5 * r^7 - 4 * M^2 * a^3 * r^8 + 2 * M * a^3 * r^9
+                    ) *
+                    cos_theta^2
+                ) * sin_theta^2
+            ) *
+            v_phi +
+            sqrt(
+                2 * M^3 * a^4 * epsilon * μ^2 * r^12 + 6 * M * μ^2 * r^19 - μ^2 * r^20 -
+                2 * (6 * M^2 + a^2) * μ^2 * r^18 +
+                (8 * M^3 + 8 * M * a^2 - M^2 * epsilon) * μ^2 * r^17 -
+                (8 * M^2 * a^2 + a^4 - 6 * M^3 * epsilon) * μ^2 * r^16 +
+                8 * (M^5 + M^3 * a^2) * epsilon * μ^2 * r^14 +
+                2 * (M * a^4 - (6 * M^4 + M^2 * a^2) * epsilon) * μ^2 * r^15 -
+                (8 * M^4 * a^2 + M^2 * a^4) * epsilon * μ^2 * r^13 -
+                (
+                    a^20 * μ^2 - 4 * M * a^18 * μ^2 * r - 4 * M * a^16 * μ^2 * r^3 +
+                    a^16 * μ^2 * r^4 +
+                    2 * (2 * M^2 * a^16 + a^18) * μ^2 * r^2
+                ) * cos_theta^16 +
+                2 *
+                (
+                    M * a^18 * μ^2 * r + 17 * M * a^14 * μ^2 * r^5 - 4 * a^14 * μ^2 * r^6 -
+                    4 * (5 * M^2 * a^14 + 2 * a^16) * μ^2 * r^4 +
+                    2 * (2 * M^3 * a^14 + 9 * M * a^16) * μ^2 * r^3 -
+                    4 * (M^2 * a^16 + a^18) * μ^2 * r^2
+                ) *
+                cos_theta^14 -
+                (
+                    M^2 * a^16 * epsilon * μ^2 * r - 4 * M^3 * a^14 * epsilon * μ^2 * r^2 -
+                    126 * M * a^12 * μ^2 * r^7 +
+                    28 * a^12 * μ^2 * r^8 +
+                    56 * (3 * M^2 * a^12 + a^14) * μ^2 * r^6 -
+                    (56 * M^3 * a^12 + 140 * M * a^14 - M^2 * a^12 * epsilon) * μ^2 * r^5 +
+                    4 * (14 * M^2 * a^14 + 7 * a^16 - M^3 * a^12 * epsilon) * μ^2 * r^4 -
+                    2 *
+                    (7 * M * a^16 - (2 * M^4 * a^12 + M^2 * a^14) * epsilon) *
+                    μ^2 *
+                    r^3
+                ) * cos_theta^12 +
+                2 *
+                (
+                    M^3 * a^14 * epsilon * μ^2 * r^2 + 133 * M * a^10 * μ^2 * r^9 -
+                    28 * a^10 * μ^2 * r^10 - 28 * (7 * M^2 * a^10 + 2 * a^12) * μ^2 * r^8 +
+                    (84 * M^3 * a^10 + 154 * M * a^12 - 3 * M^2 * a^10 * epsilon) *
+                    μ^2 *
+                    r^7 -
+                    (84 * M^2 * a^12 + 28 * a^14 - 13 * M^3 * a^10 * epsilon) * μ^2 * r^6 +
+                    2 * (2 * M^5 * a^10 + 7 * M^3 * a^12) * epsilon * μ^2 * r^4 +
+                    (21 * M * a^14 - 2 * (8 * M^4 * a^10 + 3 * M^2 * a^12) * epsilon) *
+                    μ^2 *
+                    r^5 - (4 * M^4 * a^12 + 3 * M^2 * a^14) * epsilon * μ^2 * r^3
+                ) *
+                cos_theta^10 +
+                5 *
+                (
+                    2 * M^3 * a^12 * epsilon * μ^2 * r^4 + 70 * M * a^8 * μ^2 * r^11 -
+                    14 * a^8 * μ^2 * r^12 - 28 * (4 * M^2 * a^8 + a^10) * μ^2 * r^10 +
+                    (56 * M^3 * a^8 + 84 * M * a^10 - 3 * M^2 * a^8 * epsilon) * μ^2 * r^9 -
+                    14 * (4 * M^2 * a^10 + a^12 - M^3 * a^8 * epsilon) * μ^2 * r^8 +
+                    8 * (M^5 * a^8 + 2 * M^3 * a^10) * epsilon * μ^2 * r^6 +
+                    2 *
+                    (7 * M * a^12 - (10 * M^4 * a^8 + 3 * M^2 * a^10) * epsilon) *
+                    μ^2 *
+                    r^7 - (8 * M^4 * a^10 + 3 * M^2 * a^12) * epsilon * μ^2 * r^5
+                ) *
+                cos_theta^8 +
+                2 *
+                (
+                    10 * M^3 * a^10 * epsilon * μ^2 * r^6 + 147 * M * a^6 * μ^2 * r^13 -
+                    28 * a^6 * μ^2 * r^14 - 28 * (9 * M^2 * a^6 + 2 * a^8) * μ^2 * r^12 +
+                    2 *
+                    (70 * M^3 * a^6 + 91 * M * a^8 - 5 * M^2 * a^6 * epsilon) *
+                    μ^2 *
+                    r^11 -
+                    2 *
+                    (70 * M^2 * a^8 + 14 * a^10 - 25 * M^3 * a^6 * epsilon) *
+                    μ^2 *
+                    r^10 +
+                    20 * (2 * M^5 * a^6 + 3 * M^3 * a^8) * epsilon * μ^2 * r^8 +
+                    5 *
+                    (7 * M * a^10 - 4 * (4 * M^4 * a^6 + M^2 * a^8) * epsilon) *
+                    μ^2 *
+                    r^9 - 10 * (4 * M^4 * a^8 + M^2 * a^10) * epsilon * μ^2 * r^7
+                ) *
+                cos_theta^6 +
+                (
+                    20 * M^3 * a^8 * epsilon * μ^2 * r^8 + 154 * M * a^4 * μ^2 * r^15 -
+                    28 * a^4 * μ^2 * r^16 - 56 * (5 * M^2 * a^4 + a^6) * μ^2 * r^14 +
+                    (168 * M^3 * a^4 + 196 * M * a^6 - 15 * M^2 * a^4 * epsilon) *
+                    μ^2 *
+                    r^13 -
+                    4 * (42 * M^2 * a^6 + 7 * a^8 - 20 * M^3 * a^4 * epsilon) * μ^2 * r^12 +
+                    20 * (4 * M^5 * a^4 + 5 * M^3 * a^6) * epsilon * μ^2 * r^10 +
+                    2 *
+                    (21 * M * a^8 - 5 * (14 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon) *
+                    μ^2 *
+                    r^11 - 5 * (16 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon * μ^2 * r^9
+                ) * cos_theta^4 -
+                (
+                    M^4 * a^12 * epsilon^2 * μ^2 * r^2 * cos_theta^8 -
+                    2 * M^7 * a^4 * epsilon^3 * μ^2 * r^6 +
+                    M^6 * a^4 * epsilon^3 * μ^2 * r^7 -
+                    2 * M^5 * a^4 * epsilon^2 * μ^2 * r^9 +
+                    M^4 * a^4 * epsilon^2 * μ^2 * r^10 -
+                    2 *
+                    (
+                        M^5 * a^10 * epsilon^2 * μ^2 * r^3 -
+                        2 * M^4 * a^10 * epsilon^2 * μ^2 * r^4
+                    ) *
+                    cos_theta^6 +
+                    (
+                        M^6 * a^8 * epsilon^3 * μ^2 * r^3 -
+                        6 * M^5 * a^8 * epsilon^2 * μ^2 * r^5 +
+                        6 * M^4 * a^8 * epsilon^2 * μ^2 * r^6
+                    ) * cos_theta^4 -
+                    2 *
+                    (
+                        M^7 * a^6 * epsilon^3 * μ^2 * r^4 -
+                        M^6 * a^6 * epsilon^3 * μ^2 * r^5 +
+                        3 * M^5 * a^6 * epsilon^2 * μ^2 * r^7 -
+                        2 * M^4 * a^6 * epsilon^2 * μ^2 * r^8
+                    ) *
+                    cos_theta^2
+                ) * sin_theta^4 +
+                (
+                    (
+                        2 * M^5 * a^12 * epsilon^2 * r^3 * cos_theta^6 +
+                        M^8 * a^6 * epsilon^4 * r^4 +
+                        2 * M^7 * a^6 * epsilon^3 * r^6 +
+                        M^6 * a^6 * epsilon^3 * r^7 +
+                        2 * M^5 * a^6 * epsilon^2 * r^9 +
+                        (M^6 * a^10 * epsilon^3 * r^3 + 6 * M^5 * a^10 * epsilon^2 * r^5) *
+                        cos_theta^4 +
+                        2 *
+                        (
+                            M^7 * a^8 * epsilon^3 * r^4 +
+                            M^6 * a^8 * epsilon^3 * r^5 +
+                            3 * M^5 * a^8 * epsilon^2 * r^7
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^8 -
+                    (
+                        2 * M^7 * a^6 * epsilon^3 * r^6 - 3 * M^6 * a^6 * epsilon^3 * r^7 +
+                        6 * M^7 * a^4 * epsilon^3 * r^8 +
+                        2 * M^5 * a^4 * epsilon^2 * r^11 +
+                        8 * M^4 * a^4 * epsilon * r^13 - 4 * M^3 * a^4 * epsilon * r^14 +
+                        (8 * M^6 * a^4 - 3 * M^4 * a^6) * epsilon^2 * r^10 -
+                        (4 * M^3 * a^6 * epsilon + 3 * M^4 * a^4 * epsilon^2) * r^12 -
+                        4 *
+                        (
+                            M^3 * a^16 * epsilon * r^2 - 2 * M^4 * a^14 * epsilon * r^3 +
+                            M^3 * a^14 * epsilon * r^4
+                        ) *
+                        cos_theta^10 -
+                        (2 * M^5 * a^6 * epsilon^2 + 3 * M^6 * a^4 * epsilon^3) * r^9 -
+                        (
+                            3 * M^4 * a^14 * epsilon^2 * r^2 -
+                            4 * M^5 * a^12 * epsilon^2 * r^3 -
+                            40 * M^4 * a^12 * epsilon * r^5 +
+                            20 * M^3 * a^12 * epsilon * r^6 +
+                            (20 * M^3 * a^14 * epsilon + 3 * M^4 * a^12 * epsilon^2) * r^4
+                        ) * cos_theta^8 -
+                        2 *
+                        (
+                            M^5 * a^12 * epsilon^2 * r^3 -
+                            7 * M^5 * a^10 * epsilon^2 * r^5 -
+                            40 * M^4 * a^10 * epsilon * r^7 +
+                            20 * M^3 * a^10 * epsilon * r^8 -
+                            2 * (2 * M^6 * a^10 - 3 * M^4 * a^12) * epsilon^2 * r^4 +
+                            2 *
+                            (10 * M^3 * a^12 * epsilon + 3 * M^4 * a^10 * epsilon^2) *
+                            r^6
+                        ) *
+                        cos_theta^6 -
+                        (
+                            3 * M^6 * a^10 * epsilon^3 * r^3 -
+                            4 * M^7 * a^8 * epsilon^3 * r^4 -
+                            18 * M^5 * a^8 * epsilon^2 * r^7 -
+                            80 * M^4 * a^8 * epsilon * r^9 +
+                            40 * M^3 * a^8 * epsilon * r^10 -
+                            6 * (4 * M^6 * a^8 - 3 * M^4 * a^10) * epsilon^2 * r^6 +
+                            2 *
+                            (20 * M^3 * a^10 * epsilon + 9 * M^4 * a^8 * epsilon^2) *
+                            r^8 +
+                            3 * (2 * M^5 * a^10 * epsilon^2 + M^6 * a^8 * epsilon^3) * r^5
+                        ) * cos_theta^4 +
+                        2 *
+                        (
+                            M^7 * a^8 * epsilon^3 * r^4 - 3 * M^6 * a^8 * epsilon^3 * r^5 +
+                            5 * M^7 * a^6 * epsilon^3 * r^6 +
+                            5 * M^5 * a^6 * epsilon^2 * r^9 +
+                            20 * M^4 * a^6 * epsilon * r^11 -
+                            10 * M^3 * a^6 * epsilon * r^12 +
+                            6 * (2 * M^6 * a^6 - M^4 * a^8) * epsilon^2 * r^8 -
+                            2 *
+                            (5 * M^3 * a^8 * epsilon + 3 * M^4 * a^6 * epsilon^2) *
+                            r^10 -
+                            3 * (M^5 * a^8 * epsilon^2 + M^6 * a^6 * epsilon^3) * r^7
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^6 -
+                    (
+                        4 * M^5 * a^6 * epsilon^2 * r^9 +
+                        16 * M^5 * a^4 * epsilon^2 * r^11 +
+                        8 * M^2 * a^2 * r^18 - 2 * M * a^2 * r^19 -
+                        (8 * M^3 * a^2 + 4 * M * a^4 + 3 * M^2 * a^2 * epsilon) * r^17 +
+                        2 * (4 * M^2 * a^4 + 5 * M^3 * a^2 * epsilon) * r^16 -
+                        2 * (M * a^6 + (2 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon) * r^15 -
+                        (
+                            3 * M^4 * a^2 * epsilon^2 +
+                            4 * (2 * M^5 * a^2 - 3 * M^3 * a^4) * epsilon
+                        ) * r^14 -
+                        2 *
+                        (
+                            M * a^20 * r - 4 * M^2 * a^18 * r^2 - 4 * M^2 * a^16 * r^4 +
+                            M * a^16 * r^5 +
+                            2 * (2 * M^3 * a^16 + M * a^18) * r^3
+                        ) *
+                        cos_theta^14 -
+                        3 * (M^2 * a^6 * epsilon - 4 * M^5 * a^2 * epsilon^2) * r^13 -
+                        (8 * M^6 * a^4 + 3 * M^4 * a^6) * epsilon^2 * r^10 +
+                        2 *
+                        (
+                            M^3 * a^6 * epsilon -
+                            3 * (2 * M^6 * a^2 + M^4 * a^4) * epsilon^2
+                        ) *
+                        r^12 -
+                        (
+                            3 * M^2 * a^18 * epsilon * r - 8 * M^3 * a^16 * epsilon * r^2 -
+                            56 * M^2 * a^14 * r^6 +
+                            14 * M * a^14 * r^7 +
+                            (56 * M^3 * a^14 + 28 * M * a^16 + 3 * M^2 * a^14 * epsilon) *
+                            r^5 - 8 * (7 * M^2 * a^16 + M^3 * a^14 * epsilon) * r^4 +
+                            2 *
+                            (7 * M * a^18 + (2 * M^4 * a^14 + 3 * M^2 * a^16) * epsilon) *
+                            r^3
+                        ) * cos_theta^12 +
+                        2 *
+                        (
+                            M^3 * a^16 * epsilon * r^2 - 9 * M^2 * a^16 * epsilon * r^3 +
+                            84 * M^2 * a^12 * r^8 - 21 * M * a^12 * r^9 -
+                            3 *
+                            (28 * M^3 * a^12 + 14 * M * a^14 + 3 * M^2 * a^12 * epsilon) *
+                            r^7 + (84 * M^2 * a^14 + 25 * M^3 * a^12 * epsilon) * r^6 -
+                            2 * (2 * M^5 * a^12 - 13 * M^3 * a^14) * epsilon * r^4 -
+                            3 *
+                            (
+                                7 * M * a^16 +
+                                2 * (2 * M^4 * a^12 + 3 * M^2 * a^14) * epsilon
+                            ) *
+                            r^5
+                        ) *
+                        cos_theta^10 -
+                        (
+                            3 * M^4 * a^14 * epsilon^2 * r^2 -
+                            8 * M^5 * a^12 * epsilon^2 * r^3 - 280 * M^2 * a^10 * r^10 +
+                            70 * M * a^10 * r^11 +
+                            5 *
+                            (56 * M^3 * a^10 + 28 * M * a^12 + 9 * M^2 * a^10 * epsilon) *
+                            r^9 - 10 * (28 * M^2 * a^12 + 13 * M^3 * a^10 * epsilon) * r^8 +
+                            10 *
+                            (
+                                7 * M * a^14 +
+                                3 * (2 * M^4 * a^10 + 3 * M^2 * a^12) * epsilon
+                            ) *
+                            r^7 +
+                            (
+                                3 * M^4 * a^10 * epsilon^2 +
+                                20 * (2 * M^5 * a^10 - 7 * M^3 * a^12) * epsilon
+                            ) * r^6 +
+                            (45 * M^2 * a^14 * epsilon - 8 * M^5 * a^10 * epsilon^2) * r^5 -
+                            2 *
+                            (
+                                5 * M^3 * a^14 * epsilon -
+                                (2 * M^6 * a^10 + 3 * M^4 * a^12) * epsilon^2
+                            ) *
+                            r^4
+                        ) * cos_theta^8 +
+                        2 *
+                        (
+                            2 * M^5 * a^12 * epsilon^2 * r^3 +
+                            20 * M^5 * a^10 * epsilon^2 * r^5 +
+                            140 * M^2 * a^8 * r^12 - 35 * M * a^8 * r^13 -
+                            10 *
+                            (14 * M^3 * a^8 + 7 * M * a^10 + 3 * M^2 * a^8 * epsilon) *
+                            r^11 + 10 * (14 * M^2 * a^10 + 9 * M^3 * a^8 * epsilon) * r^10 -
+                            5 *
+                            (
+                                7 * M * a^12 +
+                                4 * (2 * M^4 * a^8 + 3 * M^2 * a^10) * epsilon
+                            ) *
+                            r^9 -
+                            2 *
+                            (
+                                3 * M^4 * a^8 * epsilon^2 +
+                                10 * (2 * M^5 * a^8 - 5 * M^3 * a^10) * epsilon
+                            ) *
+                            r^8 -
+                            6 *
+                            (5 * M^2 * a^12 * epsilon - 3 * M^5 * a^8 * epsilon^2) *
+                            r^7 - 2 * (2 * M^6 * a^10 + 3 * M^4 * a^12) * epsilon^2 * r^4 +
+                            2 *
+                            (
+                                5 * M^3 * a^12 * epsilon -
+                                6 * (M^6 * a^8 + M^4 * a^10) * epsilon^2
+                            ) *
+                            r^6
+                        ) *
+                        cos_theta^6 +
+                        (
+                            12 * M^5 * a^10 * epsilon^2 * r^5 +
+                            72 * M^5 * a^8 * epsilon^2 * r^7 +
+                            168 * M^2 * a^6 * r^14 - 42 * M * a^6 * r^15 -
+                            3 *
+                            (56 * M^3 * a^6 + 28 * M * a^8 + 15 * M^2 * a^6 * epsilon) *
+                            r^13 + 28 * (6 * M^2 * a^8 + 5 * M^3 * a^6 * epsilon) * r^12 -
+                            6 *
+                            (7 * M * a^10 + 5 * (2 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon) *
+                            r^11 -
+                            2 *
+                            (
+                                9 * M^4 * a^6 * epsilon^2 +
+                                40 * (M^5 * a^6 - 2 * M^3 * a^8) * epsilon
+                            ) *
+                            r^10 -
+                            15 *
+                            (3 * M^2 * a^10 * epsilon - 4 * M^5 * a^6 * epsilon^2) *
+                            r^9 - 6 * (4 * M^6 * a^8 + 3 * M^4 * a^10) * epsilon^2 * r^6 +
+                            4 *
+                            (
+                                5 * M^3 * a^10 * epsilon -
+                                3 * (4 * M^6 * a^6 + 3 * M^4 * a^8) * epsilon^2
+                            ) *
+                            r^8
+                        ) * cos_theta^4 +
+                        2 *
+                        (
+                            6 * M^5 * a^8 * epsilon^2 * r^7 +
+                            28 * M^5 * a^6 * epsilon^2 * r^9 +
+                            28 * M^2 * a^4 * r^16 - 7 * M * a^4 * r^17 -
+                            (28 * M^3 * a^4 + 14 * M * a^6 + 9 * M^2 * a^4 * epsilon) *
+                            r^15 + (28 * M^2 * a^6 + 29 * M^3 * a^4 * epsilon) * r^14 -
+                            (7 * M * a^8 + 6 * (2 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon) *
+                            r^13 -
+                            2 *
+                            (
+                                3 * M^4 * a^4 * epsilon^2 +
+                                (10 * M^5 * a^4 - 17 * M^3 * a^6) * epsilon
+                            ) *
+                            r^12 -
+                            (9 * M^2 * a^8 * epsilon - 22 * M^5 * a^4 * epsilon^2) * r^11 -
+                            6 * (2 * M^6 * a^6 + M^4 * a^8) * epsilon^2 * r^8 +
+                            (
+                                5 * M^3 * a^8 * epsilon -
+                                4 * (5 * M^6 * a^4 + 3 * M^4 * a^6) * epsilon^2
+                            ) * r^10
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^4 -
+                    (
+                        2 * M^3 * a^6 * epsilon * r^12 + 6 * M * r^21 - r^22 -
+                        3 * (4 * M^2 + a^2) * r^20 +
+                        (8 * M^3 + 14 * M * a^2 - M^2 * epsilon) * r^19 -
+                        (20 * M^2 * a^2 + 3 * a^4 - 6 * M^3 * epsilon) * r^18 +
+                        (
+                            8 * M^3 * a^2 + 10 * M * a^4 -
+                            3 * (4 * M^4 + M^2 * a^2) * epsilon
+                        ) * r^17 -
+                        (8 * M^2 * a^4 + a^6 - 2 * (4 * M^5 + 7 * M^3 * a^2) * epsilon) *
+                        r^16 -
+                        (
+                            a^22 - 4 * M * a^20 * r - 8 * M * a^18 * r^3 -
+                            4 * M * a^16 * r^5 +
+                            a^16 * r^6 +
+                            (4 * M^2 * a^16 + 3 * a^18) * r^4 +
+                            (4 * M^2 * a^18 + 3 * a^20) * r^2
+                        ) * cos_theta^16 +
+                        2 * (4 * M^5 * a^2 + 5 * M^3 * a^4) * epsilon * r^14 +
+                        (2 * M * a^6 - (20 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon) * r^15 -
+                        (8 * M^4 * a^4 + M^2 * a^6) * epsilon * r^13 +
+                        2 *
+                        (
+                            M * a^20 * r + 17 * M * a^14 * r^7 - 4 * a^14 * r^8 -
+                            4 * (5 * M^2 * a^14 + 3 * a^16) * r^6 +
+                            (4 * M^3 * a^14 + 35 * M * a^16) * r^5 -
+                            12 * (2 * M^2 * a^16 + a^18) * r^4 +
+                            (4 * M^3 * a^16 + 19 * M * a^18) * r^3 -
+                            4 * (M^2 * a^18 + a^20) * r^2
+                        ) *
+                        cos_theta^14 -
+                        (
+                            M^2 * a^18 * epsilon * r - 4 * M^3 * a^16 * epsilon * r^2 -
+                            126 * M * a^12 * r^9 +
+                            28 * a^12 * r^10 +
+                            84 * (2 * M^2 * a^12 + a^14) * r^8 -
+                            (56 * M^3 * a^12 + 266 * M * a^14 - M^2 * a^12 * epsilon) *
+                            r^7 +
+                            4 * (56 * M^2 * a^14 + 21 * a^16 - M^3 * a^12 * epsilon) * r^6 -
+                            (
+                                56 * M^3 * a^14 + 154 * M * a^16 -
+                                (4 * M^4 * a^12 + 3 * M^2 * a^14) * epsilon
+                            ) * r^5 +
+                            4 *
+                            (14 * M^2 * a^16 + 7 * a^18 - 2 * M^3 * a^14 * epsilon) *
+                            r^4 -
+                            (14 * M * a^18 - (4 * M^4 * a^14 + 3 * M^2 * a^16) * epsilon) *
+                            r^3
+                        ) * cos_theta^12 +
+                        2 *
+                        (
+                            M^3 * a^16 * epsilon * r^2 + 133 * M * a^10 * r^11 -
+                            28 * a^10 * r^12 - 28 * (7 * M^2 * a^10 + 3 * a^12) * r^10 +
+                            (84 * M^3 * a^10 + 287 * M * a^12 - 3 * M^2 * a^10 * epsilon) *
+                            r^9 -
+                            (280 * M^2 * a^12 + 84 * a^14 - 13 * M^3 * a^10 * epsilon) *
+                            r^8 +
+                            (
+                                84 * M^3 * a^12 + 175 * M * a^14 -
+                                (16 * M^4 * a^10 + 9 * M^2 * a^12) * epsilon
+                            ) * r^7 -
+                            (
+                                84 * M^2 * a^14 + 28 * a^16 -
+                                (4 * M^5 * a^10 + 27 * M^3 * a^12) * epsilon
+                            ) * r^6 +
+                            (4 * M^5 * a^12 + 15 * M^3 * a^14) * epsilon * r^4 +
+                            (21 * M * a^16 - (20 * M^4 * a^12 + 9 * M^2 * a^14) * epsilon) *
+                            r^5 - (4 * M^4 * a^14 + 3 * M^2 * a^16) * epsilon * r^3
+                        ) *
+                        cos_theta^10 +
+                        5 *
+                        (
+                            2 * M^3 * a^14 * epsilon * r^4 + 70 * M * a^8 * r^13 -
+                            14 * a^8 * r^14 - 14 * (8 * M^2 * a^8 + 3 * a^10) * r^12 +
+                            (56 * M^3 * a^8 + 154 * M * a^10 - 3 * M^2 * a^8 * epsilon) *
+                            r^11 -
+                            14 * (12 * M^2 * a^10 + 3 * a^12 - M^3 * a^8 * epsilon) * r^10 +
+                            (
+                                56 * M^3 * a^10 + 98 * M * a^12 -
+                                (20 * M^4 * a^8 + 9 * M^2 * a^10) * epsilon
+                            ) * r^9 -
+                            2 *
+                            (
+                                28 * M^2 * a^12 + 7 * a^14 -
+                                (4 * M^5 * a^8 + 15 * M^3 * a^10) * epsilon
+                            ) *
+                            r^8 +
+                            2 * (4 * M^5 * a^10 + 9 * M^3 * a^12) * epsilon * r^6 +
+                            (14 * M * a^14 - (28 * M^4 * a^10 + 9 * M^2 * a^12) * epsilon) *
+                            r^7 - (8 * M^4 * a^12 + 3 * M^2 * a^14) * epsilon * r^5
+                        ) *
+                        cos_theta^8 +
+                        2 *
+                        (
+                            10 * M^3 * a^12 * epsilon * r^6 + 147 * M * a^6 * r^15 -
+                            28 * a^6 * r^16 - 84 * (3 * M^2 * a^6 + a^8) * r^14 +
+                            (140 * M^3 * a^6 + 329 * M * a^8 - 10 * M^2 * a^6 * epsilon) *
+                            r^13 -
+                            2 *
+                            (196 * M^2 * a^8 + 42 * a^10 - 25 * M^3 * a^6 * epsilon) *
+                            r^12 +
+                            (
+                                140 * M^3 * a^8 + 217 * M * a^10 -
+                                10 * (8 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon
+                            ) * r^11 -
+                            2 *
+                            (
+                                70 * M^2 * a^10 + 14 * a^12 -
+                                5 * (4 * M^5 * a^6 + 11 * M^3 * a^8) * epsilon
+                            ) *
+                            r^10 +
+                            10 * (4 * M^5 * a^8 + 7 * M^3 * a^10) * epsilon * r^8 +
+                            5 *
+                            (7 * M * a^12 - 6 * (4 * M^4 * a^8 + M^2 * a^10) * epsilon) *
+                            r^9 - 10 * (4 * M^4 * a^10 + M^2 * a^12) * epsilon * r^7
+                        ) *
+                        cos_theta^6 +
+                        (
+                            20 * M^3 * a^10 * epsilon * r^8 + 154 * M * a^4 * r^17 -
+                            28 * a^4 * r^18 - 28 * (10 * M^2 * a^4 + 3 * a^6) * r^16 +
+                            (168 * M^3 * a^4 + 350 * M * a^6 - 15 * M^2 * a^4 * epsilon) *
+                            r^15 -
+                            4 *
+                            (112 * M^2 * a^6 + 21 * a^8 - 20 * M^3 * a^4 * epsilon) *
+                            r^14 +
+                            (
+                                168 * M^3 * a^6 + 238 * M * a^8 -
+                                5 * (28 * M^4 * a^4 + 9 * M^2 * a^6) * epsilon
+                            ) * r^13 -
+                            4 *
+                            (
+                                42 * M^2 * a^8 + 7 * a^10 -
+                                5 * (4 * M^5 * a^4 + 9 * M^3 * a^6) * epsilon
+                            ) *
+                            r^12 +
+                            40 * (2 * M^5 * a^6 + 3 * M^3 * a^8) * epsilon * r^10 +
+                            (
+                                42 * M * a^10 -
+                                5 * (44 * M^4 * a^6 + 9 * M^2 * a^8) * epsilon
+                            ) * r^11 -
+                            5 * (16 * M^4 * a^8 + 3 * M^2 * a^10) * epsilon * r^9
+                        ) * cos_theta^4 +
+                        2 *
+                        (
+                            5 * M^3 * a^8 * epsilon * r^10 + 23 * M * a^2 * r^19 -
+                            4 * a^2 * r^20 - 4 * (11 * M^2 * a^2 + 3 * a^4) * r^18 +
+                            (28 * M^3 * a^2 + 53 * M * a^4 - 3 * M^2 * a^2 * epsilon) *
+                            r^17 -
+                            (72 * M^2 * a^4 + 12 * a^6 - 17 * M^3 * a^2 * epsilon) * r^16 +
+                            (
+                                28 * M^3 * a^4 + 37 * M * a^6 -
+                                (32 * M^4 * a^2 + 9 * M^2 * a^4) * epsilon
+                            ) * r^15 -
+                            (
+                                28 * M^2 * a^6 + 4 * a^8 -
+                                (20 * M^5 * a^2 + 39 * M^3 * a^4) * epsilon
+                            ) * r^14 +
+                            (20 * M^5 * a^4 + 27 * M^3 * a^6) * epsilon * r^12 +
+                            (7 * M * a^8 - (52 * M^4 * a^4 + 9 * M^2 * a^6) * epsilon) *
+                            r^13 - (20 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon * r^11
+                        ) *
+                        cos_theta^2
+                    ) * sin_theta^2
+                ) * v_phi^2 -
+                (
+                    2 * M^5 * a^2 * epsilon^2 * r^11 +
+                    4 * M^5 * epsilon^2 * r^13 +
+                    8 * M^3 * epsilon * r^16 +
+                    4 * M * r^19 - r^20 - (4 * M^2 + a^2) * r^18 -
+                    (a^20 - 2 * M * a^18 * r + a^18 * r^2) * cos_theta^18 +
+                    2 * (M * a^2 - M^2 * epsilon) * r^17 -
+                    2 * (4 * M^4 + M^2 * a^2) * epsilon * r^15 +
+                    (
+                        2 * M * a^18 * r + 20 * M * a^16 * r^3 - 9 * a^16 * r^4 -
+                        (4 * M^2 * a^16 + 9 * a^18) * r^2
+                    ) * cos_theta^16 - (4 * M^6 + M^4 * a^2) * epsilon^2 * r^12 +
+                    (4 * M^3 * a^2 * epsilon - M^4 * epsilon^2) * r^14 -
+                    2 *
+                    (
+                        M^2 * a^16 * epsilon * r - 2 * M^3 * a^14 * epsilon * r^2 -
+                        44 * M * a^14 * r^5 +
+                        18 * a^14 * r^6 +
+                        2 * (8 * M^2 * a^14 + 9 * a^16) * r^4 -
+                        (8 * M * a^16 - M^2 * a^14 * epsilon) * r^3
+                    ) *
+                    cos_theta^14 +
+                    2 *
+                    (
+                        2 * M^3 * a^14 * epsilon * r^2 +
+                        16 * M^3 * a^12 * epsilon * r^4 +
+                        112 * M * a^12 * r^7 - 42 * a^12 * r^8 -
+                        14 * (4 * M^2 * a^12 + 3 * a^14) * r^6 +
+                        7 * (4 * M * a^14 - M^2 * a^12 * epsilon) * r^5 -
+                        (4 * M^4 * a^12 + 7 * M^2 * a^14) * epsilon * r^3
+                    ) *
+                    cos_theta^12 -
+                    (
+                        M^4 * a^12 * epsilon^2 * r^2 - 2 * M^5 * a^10 * epsilon^2 * r^3 -
+                        108 * M^3 * a^10 * epsilon * r^6 - 364 * M * a^10 * r^9 +
+                        126 * a^10 * r^10 +
+                        14 * (16 * M^2 * a^10 + 9 * a^12) * r^8 -
+                        14 * (8 * M * a^12 - 3 * M^2 * a^10 * epsilon) * r^7 +
+                        6 * (8 * M^4 * a^10 + 7 * M^2 * a^12) * epsilon * r^5 -
+                        (24 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * r^4
+                    ) * cos_theta^10 +
+                    (
+                        2 * M^5 * a^10 * epsilon^2 * r^3 +
+                        12 * M^5 * a^8 * epsilon^2 * r^5 +
+                        200 * M^3 * a^8 * epsilon * r^8 +
+                        392 * M * a^8 * r^11 - 126 * a^8 * r^12 -
+                        14 * (20 * M^2 * a^8 + 9 * a^10) * r^10 +
+                        70 * (2 * M * a^10 - M^2 * a^8 * epsilon) * r^9 -
+                        10 * (12 * M^4 * a^8 + 7 * M^2 * a^10) * epsilon * r^7 -
+                        (4 * M^6 * a^8 + 5 * M^4 * a^10) * epsilon^2 * r^4 +
+                        5 * (12 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * r^6
+                    ) * cos_theta^8 +
+                    2 *
+                    (
+                        4 * M^5 * a^8 * epsilon^2 * r^5 +
+                        14 * M^5 * a^6 * epsilon^2 * r^7 +
+                        110 * M^3 * a^6 * epsilon * r^10 +
+                        140 * M * a^6 * r^13 - 42 * a^6 * r^14 -
+                        14 * (8 * M^2 * a^6 + 3 * a^8) * r^12 +
+                        7 * (8 * M * a^8 - 5 * M^2 * a^6 * epsilon) * r^11 -
+                        5 * (16 * M^4 * a^6 + 7 * M^2 * a^8) * epsilon * r^9 -
+                        (8 * M^6 * a^6 + 5 * M^4 * a^8) * epsilon^2 * r^6 +
+                        5 * (8 * M^3 * a^8 * epsilon - M^4 * a^6 * epsilon^2) * r^8
+                    ) *
+                    cos_theta^6 +
+                    2 *
+                    (
+                        6 * M^5 * a^6 * epsilon^2 * r^7 +
+                        16 * M^5 * a^4 * epsilon^2 * r^9 +
+                        72 * M^3 * a^4 * epsilon * r^12 +
+                        64 * M * a^4 * r^15 - 18 * a^4 * r^16 -
+                        2 * (28 * M^2 * a^4 + 9 * a^6) * r^14 +
+                        7 * (4 * M * a^6 - 3 * M^2 * a^4 * epsilon) * r^13 -
+                        3 * (20 * M^4 * a^4 + 7 * M^2 * a^6) * epsilon * r^11 -
+                        (12 * M^6 * a^4 + 5 * M^4 * a^6) * epsilon^2 * r^8 +
+                        5 * (6 * M^3 * a^6 * epsilon - M^4 * a^4 * epsilon^2) * r^10
+                    ) *
+                    cos_theta^4 +
+                    (
+                        8 * M^5 * a^4 * epsilon^2 * r^9 +
+                        18 * M^5 * a^2 * epsilon^2 * r^11 +
+                        52 * M^3 * a^2 * epsilon * r^14 +
+                        34 * M * a^2 * r^17 - 9 * a^2 * r^18 -
+                        (32 * M^2 * a^2 + 9 * a^4) * r^16 +
+                        2 * (8 * M * a^4 - 7 * M^2 * a^2 * epsilon) * r^15 -
+                        2 * (24 * M^4 * a^2 + 7 * M^2 * a^4) * epsilon * r^13 -
+                        (16 * M^6 * a^2 + 5 * M^4 * a^4) * epsilon^2 * r^10 +
+                        (24 * M^3 * a^4 * epsilon - 5 * M^4 * a^2 * epsilon^2) * r^12
+                    ) * cos_theta^2 -
+                    (
+                        M^2 * a^16 * epsilon * r * cos_theta^14 -
+                        2 * M^7 * a^2 * epsilon^3 * r^8 + M^6 * a^2 * epsilon^3 * r^9 -
+                        4 * M^5 * a^2 * epsilon^2 * r^11 +
+                        2 * M^4 * a^2 * epsilon^2 * r^12 - 2 * M^3 * a^2 * epsilon * r^14 +
+                        M^2 * a^2 * epsilon * r^15 -
+                        (2 * M^3 * a^14 * epsilon * r^2 - 7 * M^2 * a^14 * epsilon * r^3) *
+                        cos_theta^12 +
+                        (
+                            2 * M^4 * a^12 * epsilon^2 * r^2 -
+                            12 * M^3 * a^12 * epsilon * r^4 +
+                            21 * M^2 * a^12 * epsilon * r^5
+                        ) * cos_theta^10 -
+                        (
+                            4 * M^5 * a^10 * epsilon^2 * r^3 -
+                            10 * M^4 * a^10 * epsilon^2 * r^4 +
+                            30 * M^3 * a^10 * epsilon * r^6 -
+                            35 * M^2 * a^10 * epsilon * r^7
+                        ) * cos_theta^8 +
+                        (
+                            M^6 * a^8 * epsilon^3 * r^3 - 16 * M^5 * a^8 * epsilon^2 * r^5 +
+                            20 * M^4 * a^8 * epsilon^2 * r^6 -
+                            40 * M^3 * a^8 * epsilon * r^8 + 35 * M^2 * a^8 * epsilon * r^9
+                        ) * cos_theta^6 -
+                        (
+                            2 * M^7 * a^6 * epsilon^3 * r^4 -
+                            3 * M^6 * a^6 * epsilon^3 * r^5 +
+                            24 * M^5 * a^6 * epsilon^2 * r^7 -
+                            20 * M^4 * a^6 * epsilon^2 * r^8 +
+                            30 * M^3 * a^6 * epsilon * r^10 -
+                            21 * M^2 * a^6 * epsilon * r^11
+                        ) * cos_theta^4 -
+                        (
+                            4 * M^7 * a^4 * epsilon^3 * r^6 -
+                            3 * M^6 * a^4 * epsilon^3 * r^7 +
+                            16 * M^5 * a^4 * epsilon^2 * r^9 -
+                            10 * M^4 * a^4 * epsilon^2 * r^10 +
+                            12 * M^3 * a^4 * epsilon * r^12 -
+                            7 * M^2 * a^4 * epsilon * r^13
+                        ) * cos_theta^2
+                    ) * sin_theta^2
+                ) * v_r^2 -
+                (
+                    2 * M^3 * a^4 * epsilon * r^14 + 6 * M * r^21 - r^22 -
+                    2 * (6 * M^2 + a^2) * r^20 +
+                    (8 * M^3 + 8 * M * a^2 - M^2 * epsilon) * r^19 -
+                    (8 * M^2 * a^2 + a^4 - 6 * M^3 * epsilon) * r^18 -
+                    (
+                        a^22 - 4 * M * a^20 * r - 4 * M * a^18 * r^3 +
+                        a^18 * r^4 +
+                        2 * (2 * M^2 * a^18 + a^20) * r^2
+                    ) * cos_theta^18 +
+                    8 * (M^5 + M^3 * a^2) * epsilon * r^16 +
+                    2 * (M * a^4 - (6 * M^4 + M^2 * a^2) * epsilon) * r^17 -
+                    (8 * M^4 * a^2 + M^2 * a^4) * epsilon * r^15 +
+                    (
+                        2 * M * a^20 * r + 38 * M * a^16 * r^5 - 9 * a^16 * r^6 -
+                        2 * (22 * M^2 * a^16 + 9 * a^18) * r^4 +
+                        8 * (M^3 * a^16 + 5 * M * a^18) * r^3 -
+                        (8 * M^2 * a^18 + 9 * a^20) * r^2
+                    ) * cos_theta^16 -
+                    (
+                        M^2 * a^18 * epsilon * r - 4 * M^3 * a^16 * epsilon * r^2 -
+                        160 * M * a^14 * r^7 +
+                        36 * a^14 * r^8 +
+                        8 * (26 * M^2 * a^14 + 9 * a^16) * r^6 -
+                        (64 * M^3 * a^14 + 176 * M * a^16 - M^2 * a^14 * epsilon) * r^5 +
+                        4 * (16 * M^2 * a^16 + 9 * a^18 - M^3 * a^14 * epsilon) * r^4 -
+                        2 * (8 * M * a^18 - (2 * M^4 * a^14 + M^2 * a^16) * epsilon) * r^3
+                    ) * cos_theta^14 +
+                    (
+                        2 * M^3 * a^16 * epsilon * r^2 + 392 * M * a^12 * r^9 -
+                        84 * a^12 * r^10 - 56 * (10 * M^2 * a^12 + 3 * a^14) * r^8 +
+                        7 * (32 * M^3 * a^12 + 64 * M * a^14 - M^2 * a^12 * epsilon) * r^7 -
+                        2 *
+                        (112 * M^2 * a^14 + 42 * a^16 - 15 * M^3 * a^12 * epsilon) *
+                        r^6 +
+                        8 * (M^5 * a^12 + 4 * M^3 * a^14) * epsilon * r^4 +
+                        2 *
+                        (28 * M * a^16 - (18 * M^4 * a^12 + 7 * M^2 * a^14) * epsilon) *
+                        r^5 - (8 * M^4 * a^14 + 7 * M^2 * a^16) * epsilon * r^3
+                    ) * cos_theta^12 +
+                    (
+                        12 * M^3 * a^14 * epsilon * r^4 + 616 * M * a^10 * r^11 -
+                        126 * a^10 * r^12 - 28 * (34 * M^2 * a^10 + 9 * a^12) * r^10 +
+                        7 *
+                        (64 * M^3 * a^10 + 104 * M * a^12 - 3 * M^2 * a^10 * epsilon) *
+                        r^9 -
+                        2 *
+                        (224 * M^2 * a^12 + 63 * a^14 - 48 * M^3 * a^10 * epsilon) *
+                        r^8 +
+                        12 * (4 * M^5 * a^10 + 9 * M^3 * a^12) * epsilon * r^6 +
+                        2 *
+                        (56 * M * a^14 - 3 * (22 * M^4 * a^10 + 7 * M^2 * a^12) * epsilon) *
+                        r^7 - 3 * (16 * M^4 * a^12 + 7 * M^2 * a^14) * epsilon * r^5
+                    ) * cos_theta^10 +
+                    (
+                        30 * M^3 * a^12 * epsilon * r^6 + 644 * M * a^8 * r^13 -
+                        126 * a^8 * r^14 - 28 * (38 * M^2 * a^8 + 9 * a^10) * r^12 +
+                        7 *
+                        (80 * M^3 * a^8 + 112 * M * a^10 - 5 * M^2 * a^8 * epsilon) *
+                        r^11 -
+                        2 *
+                        (280 * M^2 * a^10 + 63 * a^12 - 85 * M^3 * a^8 * epsilon) *
+                        r^10 +
+                        40 * (3 * M^5 * a^8 + 5 * M^3 * a^10) * epsilon * r^8 +
+                        10 *
+                        (14 * M * a^12 - (26 * M^4 * a^8 + 7 * M^2 * a^10) * epsilon) *
+                        r^9 - 5 * (24 * M^4 * a^10 + 7 * M^2 * a^12) * epsilon * r^7
+                    ) * cos_theta^8 +
+                    (
+                        40 * M^3 * a^10 * epsilon * r^8 + 448 * M * a^6 * r^15 -
+                        84 * a^6 * r^16 - 56 * (14 * M^2 * a^6 + 3 * a^8) * r^14 +
+                        7 *
+                        (64 * M^3 * a^6 + 80 * M * a^8 - 5 * M^2 * a^6 * epsilon) *
+                        r^13 -
+                        4 *
+                        (112 * M^2 * a^8 + 21 * a^10 - 45 * M^3 * a^6 * epsilon) *
+                        r^12 +
+                        20 * (8 * M^5 * a^6 + 11 * M^3 * a^8) * epsilon * r^10 +
+                        2 *
+                        (56 * M * a^10 - 5 * (30 * M^4 * a^6 + 7 * M^2 * a^8) * epsilon) *
+                        r^11 - 5 * (32 * M^4 * a^8 + 7 * M^2 * a^10) * epsilon * r^9
+                    ) * cos_theta^6 +
+                    (
+                        30 * M^3 * a^8 * epsilon * r^10 + 200 * M * a^4 * r^17 -
+                        36 * a^4 * r^18 - 8 * (46 * M^2 * a^4 + 9 * a^6) * r^16 +
+                        (224 * M^3 * a^4 + 256 * M * a^6 - 21 * M^2 * a^4 * epsilon) *
+                        r^15 -
+                        2 * (112 * M^2 * a^6 + 18 * a^8 - 57 * M^3 * a^4 * epsilon) * r^14 +
+                        24 * (5 * M^5 * a^4 + 6 * M^3 * a^6) * epsilon * r^12 +
+                        2 *
+                        (28 * M * a^8 - 3 * (34 * M^4 * a^4 + 7 * M^2 * a^6) * epsilon) *
+                        r^13 - 3 * (40 * M^4 * a^6 + 7 * M^2 * a^8) * epsilon * r^11
+                    ) * cos_theta^4 -
+                    (
+                        M^4 * a^14 * epsilon^2 * r^2 * cos_theta^10 -
+                        2 * M^7 * a^4 * epsilon^3 * r^8 + M^6 * a^4 * epsilon^3 * r^9 -
+                        2 * M^5 * a^4 * epsilon^2 * r^11 + M^4 * a^4 * epsilon^2 * r^12 -
+                        (
+                            2 * M^5 * a^12 * epsilon^2 * r^3 -
+                            5 * M^4 * a^12 * epsilon^2 * r^4
+                        ) * cos_theta^8 +
+                        (
+                            M^6 * a^10 * epsilon^3 * r^3 -
+                            8 * M^5 * a^10 * epsilon^2 * r^5 +
+                            10 * M^4 * a^10 * epsilon^2 * r^6
+                        ) * cos_theta^6 -
+                        (
+                            2 * M^7 * a^8 * epsilon^3 * r^4 -
+                            3 * M^6 * a^8 * epsilon^3 * r^5 +
+                            12 * M^5 * a^8 * epsilon^2 * r^7 -
+                            10 * M^4 * a^8 * epsilon^2 * r^8
+                        ) * cos_theta^4 -
+                        (
+                            4 * M^7 * a^6 * epsilon^3 * r^6 -
+                            3 * M^6 * a^6 * epsilon^3 * r^7 +
+                            8 * M^5 * a^6 * epsilon^2 * r^9 -
+                            5 * M^4 * a^6 * epsilon^2 * r^10
+                        ) * cos_theta^2
+                    ) * sin_theta^4 +
+                    (
+                        12 * M^3 * a^6 * epsilon * r^12 + 52 * M * a^2 * r^19 -
+                        9 * a^2 * r^20 - 2 * (50 * M^2 * a^2 + 9 * a^4) * r^18 +
+                        (64 * M^3 * a^2 + 68 * M * a^4 - 7 * M^2 * a^2 * epsilon) * r^17 -
+                        (64 * M^2 * a^4 + 9 * a^6 - 40 * M^3 * a^2 * epsilon) * r^16 +
+                        4 * (12 * M^5 * a^2 + 13 * M^3 * a^4) * epsilon * r^14 +
+                        2 *
+                        (8 * M * a^6 - (38 * M^4 * a^2 + 7 * M^2 * a^4) * epsilon) *
+                        r^15 - (48 * M^4 * a^4 + 7 * M^2 * a^6) * epsilon * r^13
+                    ) * cos_theta^2 +
+                    2 *
+                    (
+                        2 * M^5 * a^4 * epsilon^2 * r^11 +
+                        4 * M^5 * a^2 * epsilon^2 * r^13 +
+                        4 * M^3 * a^2 * epsilon * r^16 - M^2 * a^2 * epsilon * r^17 -
+                        (4 * M^4 * a^2 + M^2 * a^4) * epsilon * r^15 -
+                        (4 * M^6 * a^2 + M^4 * a^4) * epsilon^2 * r^12 +
+                        (2 * M^3 * a^4 * epsilon - M^4 * a^2 * epsilon^2) * r^14 -
+                        (
+                            M^2 * a^18 * epsilon * r - 2 * M^3 * a^16 * epsilon * r^2 +
+                            M^2 * a^16 * epsilon * r^3
+                        ) * cos_theta^14 +
+                        (
+                            2 * M^3 * a^16 * epsilon * r^2 +
+                            16 * M^3 * a^14 * epsilon * r^4 -
+                            7 * M^2 * a^14 * epsilon * r^5 -
+                            (4 * M^4 * a^14 + 7 * M^2 * a^16) * epsilon * r^3
+                        ) * cos_theta^12 -
+                        (
+                            M^4 * a^14 * epsilon^2 * r^2 -
+                            2 * M^5 * a^12 * epsilon^2 * r^3 -
+                            54 * M^3 * a^12 * epsilon * r^6 +
+                            21 * M^2 * a^12 * epsilon * r^7 +
+                            3 * (8 * M^4 * a^12 + 7 * M^2 * a^14) * epsilon * r^5 -
+                            (12 * M^3 * a^14 * epsilon - M^4 * a^12 * epsilon^2) * r^4
+                        ) * cos_theta^10 +
+                        (
+                            2 * M^5 * a^12 * epsilon^2 * r^3 +
+                            12 * M^5 * a^10 * epsilon^2 * r^5 +
+                            100 * M^3 * a^10 * epsilon * r^8 -
+                            35 * M^2 * a^10 * epsilon * r^9 -
+                            5 * (12 * M^4 * a^10 + 7 * M^2 * a^12) * epsilon * r^7 -
+                            (4 * M^6 * a^10 + 5 * M^4 * a^12) * epsilon^2 * r^4 +
+                            5 * (6 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * r^6
+                        ) * cos_theta^8 +
+                        (
+                            8 * M^5 * a^10 * epsilon^2 * r^5 +
+                            28 * M^5 * a^8 * epsilon^2 * r^7 +
+                            110 * M^3 * a^8 * epsilon * r^10 -
+                            35 * M^2 * a^8 * epsilon * r^11 -
+                            5 * (16 * M^4 * a^8 + 7 * M^2 * a^10) * epsilon * r^9 -
+                            2 * (8 * M^6 * a^8 + 5 * M^4 * a^10) * epsilon^2 * r^6 +
+                            10 * (4 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * r^8
+                        ) * cos_theta^6 +
+                        (
+                            12 * M^5 * a^8 * epsilon^2 * r^7 +
+                            32 * M^5 * a^6 * epsilon^2 * r^9 +
+                            72 * M^3 * a^6 * epsilon * r^12 -
+                            21 * M^2 * a^6 * epsilon * r^13 -
+                            3 * (20 * M^4 * a^6 + 7 * M^2 * a^8) * epsilon * r^11 -
+                            2 * (12 * M^6 * a^6 + 5 * M^4 * a^8) * epsilon^2 * r^8 +
+                            10 * (3 * M^3 * a^8 * epsilon - M^4 * a^6 * epsilon^2) * r^10
+                        ) * cos_theta^4 +
+                        (
+                            8 * M^5 * a^6 * epsilon^2 * r^9 +
+                            18 * M^5 * a^4 * epsilon^2 * r^11 +
+                            26 * M^3 * a^4 * epsilon * r^14 -
+                            7 * M^2 * a^4 * epsilon * r^15 -
+                            (24 * M^4 * a^4 + 7 * M^2 * a^6) * epsilon * r^13 -
+                            (16 * M^6 * a^4 + 5 * M^4 * a^6) * epsilon^2 * r^10 +
+                            (12 * M^3 * a^6 * epsilon - 5 * M^4 * a^4 * epsilon^2) * r^12
+                        ) * cos_theta^2
+                    ) *
+                    sin_theta^2
+                ) * v_theta^2 +
+                2 *
+                (
+                    5 * M^3 * a^6 * epsilon * μ^2 * r^10 + 23 * M * a^2 * μ^2 * r^17 -
+                    4 * a^2 * μ^2 * r^18 - 4 * (11 * M^2 * a^2 + 2 * a^4) * μ^2 * r^16 +
+                    (28 * M^3 * a^2 + 30 * M * a^4 - 3 * M^2 * a^2 * epsilon) * μ^2 * r^15 -
+                    (28 * M^2 * a^4 + 4 * a^6 - 17 * M^3 * a^2 * epsilon) * μ^2 * r^14 +
+                    2 * (10 * M^5 * a^2 + 11 * M^3 * a^4) * epsilon * μ^2 * r^12 +
+                    (7 * M * a^6 - 2 * (16 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon) *
+                    μ^2 *
+                    r^13 - (20 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon * μ^2 * r^11
+                ) *
+                cos_theta^2 +
+                2 *
+                (
+                    2 * M^5 * a^4 * epsilon^2 * μ^2 * r^9 +
+                    4 * M^5 * a^2 * epsilon^2 * μ^2 * r^11 +
+                    4 * M^3 * a^2 * epsilon * μ^2 * r^14 -
+                    M^2 * a^2 * epsilon * μ^2 * r^15 -
+                    (4 * M^4 * a^2 + M^2 * a^4) * epsilon * μ^2 * r^13 -
+                    (4 * M^6 * a^2 + M^4 * a^4) * epsilon^2 * μ^2 * r^10 +
+                    (2 * M^3 * a^4 * epsilon - M^4 * a^2 * epsilon^2) * μ^2 * r^12 -
+                    (
+                        M^2 * a^16 * epsilon * μ^2 * r -
+                        2 * M^3 * a^14 * epsilon * μ^2 * r^2 +
+                        M^2 * a^14 * epsilon * μ^2 * r^3
+                    ) * cos_theta^12 +
+                    2 *
+                    (
+                        M^3 * a^14 * epsilon * μ^2 * r^2 +
+                        7 * M^3 * a^12 * epsilon * μ^2 * r^4 -
+                        3 * M^2 * a^12 * epsilon * μ^2 * r^5 -
+                        (2 * M^4 * a^12 + 3 * M^2 * a^14) * epsilon * μ^2 * r^3
+                    ) *
+                    cos_theta^10 -
+                    (
+                        M^4 * a^12 * epsilon^2 * μ^2 * r^2 -
+                        2 * M^5 * a^10 * epsilon^2 * μ^2 * r^3 -
+                        40 * M^3 * a^10 * epsilon * μ^2 * r^6 +
+                        15 * M^2 * a^10 * epsilon * μ^2 * r^7 +
+                        5 * (4 * M^4 * a^10 + 3 * M^2 * a^12) * epsilon * μ^2 * r^5 -
+                        (10 * M^3 * a^12 * epsilon - M^4 * a^10 * epsilon^2) * μ^2 * r^4
+                    ) * cos_theta^8 +
+                    2 *
+                    (
+                        M^5 * a^10 * epsilon^2 * μ^2 * r^3 +
+                        5 * M^5 * a^8 * epsilon^2 * μ^2 * r^5 +
+                        30 * M^3 * a^8 * epsilon * μ^2 * r^8 -
+                        10 * M^2 * a^8 * epsilon * μ^2 * r^9 -
+                        10 * (2 * M^4 * a^8 + M^2 * a^10) * epsilon * μ^2 * r^7 -
+                        2 * (M^6 * a^8 + M^4 * a^10) * epsilon^2 * μ^2 * r^4 +
+                        2 * (5 * M^3 * a^10 * epsilon - M^4 * a^8 * epsilon^2) * μ^2 * r^6
+                    ) *
+                    cos_theta^6 +
+                    (
+                        6 * M^5 * a^8 * epsilon^2 * μ^2 * r^5 +
+                        18 * M^5 * a^6 * epsilon^2 * μ^2 * r^7 +
+                        50 * M^3 * a^6 * epsilon * μ^2 * r^10 -
+                        15 * M^2 * a^6 * epsilon * μ^2 * r^11 -
+                        5 * (8 * M^4 * a^6 + 3 * M^2 * a^8) * epsilon * μ^2 * r^9 -
+                        6 * (2 * M^6 * a^6 + M^4 * a^8) * epsilon^2 * μ^2 * r^6 +
+                        2 *
+                        (10 * M^3 * a^8 * epsilon - 3 * M^4 * a^6 * epsilon^2) *
+                        μ^2 *
+                        r^8
+                    ) * cos_theta^4 +
+                    2 *
+                    (
+                        3 * M^5 * a^6 * epsilon^2 * μ^2 * r^7 +
+                        7 * M^5 * a^4 * epsilon^2 * μ^2 * r^9 +
+                        11 * M^3 * a^4 * epsilon * μ^2 * r^12 -
+                        3 * M^2 * a^4 * epsilon * μ^2 * r^13 -
+                        (10 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon * μ^2 * r^11 -
+                        2 * (3 * M^6 * a^4 + M^4 * a^6) * epsilon^2 * μ^2 * r^8 +
+                        (5 * M^3 * a^6 * epsilon - 2 * M^4 * a^4 * epsilon^2) * μ^2 * r^10
+                    ) *
+                    cos_theta^2
+                ) *
+                sin_theta^2,
+            ) * (a^2 * cos_theta^2 + r^2)
+        ) / (
+            2 * M^3 * a^2 * epsilon * r^6 + 4 * M^3 * epsilon * r^8 + 4 * M * r^11 - r^12 -
+            (4 * M^2 + a^2) * r^10 - (a^12 - 2 * M * a^10 * r + a^10 * r^2) * cos_theta^10 +
+            (2 * M * a^2 - M^2 * epsilon) * r^9 - (4 * M^4 + M^2 * a^2) * epsilon * r^7 +
+            (
+                2 * M * a^10 * r + 12 * M * a^8 * r^3 - 5 * a^8 * r^4 -
+                (4 * M^2 * a^8 + 5 * a^10) * r^2
+            ) * cos_theta^8 -
+            (
+                M^2 * a^8 * epsilon * r - 2 * M^3 * a^6 * epsilon * r^2 -
+                28 * M * a^6 * r^5 +
+                10 * a^6 * r^6 +
+                2 * (8 * M^2 * a^6 + 5 * a^8) * r^4 -
+                (8 * M * a^8 - M^2 * a^6 * epsilon) * r^3
+            ) * cos_theta^6 +
+            (
+                2 * M^3 * a^6 * epsilon * r^2 +
+                8 * M^3 * a^4 * epsilon * r^4 +
+                32 * M * a^4 * r^7 - 10 * a^4 * r^8 - 2 * (12 * M^2 * a^4 + 5 * a^6) * r^6 +
+                3 * (4 * M * a^6 - M^2 * a^4 * epsilon) * r^5 -
+                (4 * M^4 * a^4 + 3 * M^2 * a^6) * epsilon * r^3
+            ) * cos_theta^4 +
+            (
+                4 * M^3 * a^4 * epsilon * r^4 +
+                10 * M^3 * a^2 * epsilon * r^6 +
+                18 * M * a^2 * r^9 - 5 * a^2 * r^10 - (16 * M^2 * a^2 + 5 * a^4) * r^8 +
+                (8 * M * a^4 - 3 * M^2 * a^2 * epsilon) * r^7 -
+                (8 * M^4 * a^2 + 3 * M^2 * a^4) * epsilon * r^5
+            ) * cos_theta^2 -
+            (
+                M^2 * a^8 * epsilon * r * cos_theta^6 - 2 * M^5 * a^2 * epsilon^2 * r^3 +
+                M^4 * a^2 * epsilon^2 * r^4 - 2 * M^3 * a^2 * epsilon * r^6 +
+                M^2 * a^2 * epsilon * r^7 -
+                (2 * M^3 * a^6 * epsilon * r^2 - 3 * M^2 * a^6 * epsilon * r^3) *
+                cos_theta^4 +
+                (
+                    M^4 * a^4 * epsilon^2 * r^2 - 4 * M^3 * a^4 * epsilon * r^4 +
+                    3 * M^2 * a^4 * epsilon * r^5
+                ) * cos_theta^2
+            ) * sin_theta^2
+        )
+    end
+end
+
+@inline function jacobian(u, M, a, epsilon)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        comp1 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        comp2 = @SMatrix [
+            (2*M*a^6*cos_theta^6-8*M^3*epsilon*r^3+3*M^2*epsilon*r^4-2*M*r^6-(M^2*a^4*epsilon-2*M*a^4*r^2)*cos_theta^4+2*(2*M^3*a^2*epsilon*r+M^2*a^2*epsilon*r^2-M*a^2*r^4)*cos_theta^2)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 -2*(M*a^7*cos_theta^6+M*a^5*r^2*cos_theta^4-4*M^3*a*epsilon*r^3-M*a*r^6+(2*M^3*a^3*epsilon*r-M*a^3*r^4)*cos_theta^2)*sin_theta^2/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
+            0 (2*M^4*a^2*epsilon^2*r^3+4*M^2*a^2*epsilon*r^6+4*M^3*epsilon*r^7-3*M^2*epsilon*r^8+2*a^2*r^9-2*M*r^10+2*(M*a^10-a^10*r)*cos_theta^10+(M^2*a^8*epsilon+2*a^10*r+6*M*a^8*r^2-8*a^8*r^3)*cos_theta^8-4*(M^2*a^6*epsilon*r^2-2*a^8*r^3-M*a^6*r^4+3*a^6*r^5)*cos_theta^6+2*(2*M^2*a^6*epsilon*r^2+2*M^3*a^4*epsilon*r^3-7*M^2*a^4*epsilon*r^4+6*a^6*r^5-2*M*a^4*r^6-4*a^4*r^7)*cos_theta^4-2*(M^4*a^2*epsilon^2*r^3-4*M^2*a^4*epsilon*r^4-4*M^3*a^2*epsilon*r^5+6*M^2*a^2*epsilon*r^6-4*a^4*r^7+3*M*a^2*r^8+a^2*r^9)*cos_theta^2)/(M^4*a^4*epsilon^2*r^2*sin_theta^4+a^4*r^8-4*M*a^2*r^9-4*M*r^11+r^12+2*(2*M^2+a^2)*r^10+(a^12-4*M*a^10*r-4*M*a^8*r^3+a^8*r^4+2*(2*M^2*a^8+a^10)*r^2)*cos_theta^8+4*(a^10*r^2-4*M*a^8*r^3-4*M*a^6*r^5+a^6*r^6+2*(2*M^2*a^6+a^8)*r^4)*cos_theta^6+6*(a^8*r^4-4*M*a^6*r^5-4*M*a^4*r^7+a^4*r^8+2*(2*M^2*a^4+a^6)*r^6)*cos_theta^4+4*(a^6*r^6-4*M*a^4*r^7-4*M*a^2*r^9+a^2*r^10+2*(2*M^2*a^2+a^4)*r^8)*cos_theta^2+2*(M^2*a^4*epsilon*r^5-2*M^3*a^2*epsilon*r^6+M^2*a^2*epsilon*r^7+(M^2*a^8*epsilon*r-2*M^3*a^6*epsilon*r^2+M^2*a^6*epsilon*r^3)*cos_theta^4+2*(M^2*a^6*epsilon*r^3-2*M^3*a^4*epsilon*r^4+M^2*a^4*epsilon*r^5)*cos_theta^2)*sin_theta^2) 0 0
+            0 0 2*r 0
+            -2*(M*a^7*cos_theta^6+M*a^5*r^2*cos_theta^4-4*M^3*a*epsilon*r^3-M*a*r^6+(2*M^3*a^3*epsilon*r-M*a^3*r^4)*cos_theta^2)*sin_theta^2/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 ((2*M*a^8*cos_theta^6-8*M^3*a^2*epsilon*r^3-3*M^2*a^2*epsilon*r^4-2*M*a^2*r^6+(M^2*a^6*epsilon+2*M*a^6*r^2)*cos_theta^4+2*(2*M^3*a^4*epsilon*r-M^2*a^4*epsilon*r^2-M*a^4*r^4)*cos_theta^2)*sin_theta^4+2*(a^8*r*cos_theta^8+4*a^6*r^3*cos_theta^6+6*a^4*r^5*cos_theta^4+4*a^2*r^7*cos_theta^2+r^9)*sin_theta^2)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
+        ]
+        comp3 = @SMatrix [
+            4*(M*a^6*r*cos_theta^5-(M^2*a^4*epsilon*r-2*M*a^4*r^3)*cos_theta^3+(3*M^3*a^2*epsilon*r^2-M^2*a^2*epsilon*r^3+M*a^2*r^5)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 -4*((M*a^7*r+M*a^5*r^3)*cos_theta^5-2*(M^3*a^3*epsilon*r^2-M*a^5*r^3-M*a^3*r^5)*cos_theta^3+(3*M^3*a^3*epsilon*r^2+M^3*a*epsilon*r^4+M*a^3*r^5+M*a*r^7)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
+            0 -2*((a^12-2*M*a^10*r+a^10*r^2)*cos_theta^9-2*(M^2*a^8*epsilon*r-2*a^10*r^2+4*M*a^8*r^3-2*a^8*r^4)*cos_theta^7+2*(M^2*a^8*epsilon*r+M^3*a^6*epsilon*r^2-2*M^2*a^6*epsilon*r^3+3*a^8*r^4-6*M*a^6*r^5+3*a^6*r^6)*cos_theta^5+2*(2*M^2*a^6*epsilon*r^3+2*M^3*a^4*epsilon*r^4-M^2*a^4*epsilon*r^5+2*a^6*r^6-4*M*a^4*r^7+2*a^4*r^8)*cos_theta^3+(M^4*a^4*epsilon^2*r^2+M^4*a^2*epsilon^2*r^4+2*M^2*a^4*epsilon*r^5+2*M^3*a^2*epsilon*r^6+a^4*r^8-2*M*a^2*r^9+a^2*r^10)*cos_theta)*sin_theta/(M^4*a^4*epsilon^2*r^2*sin_theta^4+a^4*r^8-4*M*a^2*r^9-4*M*r^11+r^12+2*(2*M^2+a^2)*r^10+(a^12-4*M*a^10*r-4*M*a^8*r^3+a^8*r^4+2*(2*M^2*a^8+a^10)*r^2)*cos_theta^8+4*(a^10*r^2-4*M*a^8*r^3-4*M*a^6*r^5+a^6*r^6+2*(2*M^2*a^6+a^8)*r^4)*cos_theta^6+6*(a^8*r^4-4*M*a^6*r^5-4*M*a^4*r^7+a^4*r^8+2*(2*M^2*a^4+a^6)*r^6)*cos_theta^4+4*(a^6*r^6-4*M*a^4*r^7-4*M*a^2*r^9+a^2*r^10+2*(2*M^2*a^2+a^4)*r^8)*cos_theta^2+2*(M^2*a^4*epsilon*r^5-2*M^3*a^2*epsilon*r^6+M^2*a^2*epsilon*r^7+(M^2*a^8*epsilon*r-2*M^3*a^6*epsilon*r^2+M^2*a^6*epsilon*r^3)*cos_theta^4+2*(M^2*a^6*epsilon*r^3-2*M^3*a^4*epsilon*r^4+M^2*a^4*epsilon*r^5)*cos_theta^2)*sin_theta^2) 0 0
+            0 0 -2*a^2*cos_theta*sin_theta 0
+            -4*((M*a^7*r+M*a^5*r^3)*cos_theta^5-2*(M^3*a^3*epsilon*r^2-M*a^5*r^3-M*a^3*r^5)*cos_theta^3+(3*M^3*a^3*epsilon*r^2+M^3*a*epsilon*r^4+M*a^3*r^5+M*a*r^7)*cos_theta)*sin_theta/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8) 0 0 2*(2*(M*a^8*r*cos_theta^5+(M^2*a^6*epsilon*r+2*M*a^6*r^3)*cos_theta^3+(3*M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+M*a^4*r^5)*cos_theta)*sin_theta^5+2*(2*M*a^8*r*cos_theta^7+(M^2*a^6*epsilon*r+6*M*a^6*r^3)*cos_theta^5+2*(M^3*a^4*epsilon*r^2+M^2*a^4*epsilon*r^3+3*M*a^4*r^5)*cos_theta^3+(2*M^3*a^2*epsilon*r^4+M^2*a^2*epsilon*r^5+2*M*a^2*r^7)*cos_theta)*sin_theta^3+((a^10+a^8*r^2)*cos_theta^9+4*(a^8*r^2+a^6*r^4)*cos_theta^7+6*(a^6*r^4+a^4*r^6)*cos_theta^5+4*(a^4*r^6+a^2*r^8)*cos_theta^3+(a^2*r^8+r^10)*cos_theta)*sin_theta)/(a^8*cos_theta^8+4*a^6*r^2*cos_theta^6+6*a^4*r^4*cos_theta^4+4*a^2*r^6*cos_theta^2+r^8)
+        ]
+        comp4 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        (comp1, comp2, comp3, comp4)
+    end
+end
+
+@inline function metric(u, M, a, epsilon)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            (M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)*(2*M*r/(a^2*cos_theta^2+r^2)-1) 0 0 -2*(M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2)
+            0 (a^2*cos_theta^2+r^2)*(M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)/(M^2*a^2*epsilon*r*sin_theta^2/(a^2*cos_theta^2+r^2)^2+a^2-2*M*r+r^2) 0 0
+            0 0 a^2*cos_theta^2+r^2 0
+            -2*(M^2*epsilon*r/(a^2*cos_theta^2+r^2)^2+1)*M*a*r*sin_theta^2/(a^2*cos_theta^2+r^2) 0 0 (a^2*cos_theta^2+2*M*r+r^2)*M^2*a^2*epsilon*r*sin_theta^4/(a^2*cos_theta^2+r^2)^3+(2*M*a^2*r*sin_theta^2/(a^2*cos_theta^2+r^2)+a^2+r^2)*sin_theta^2
+        ]
+    end
+end
+
+@inline function inverse_metric(u, M, a, epsilon)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            -(a^2 * r^8 + r^10 + (a^10 + a^8 * r^2) * cos_theta^8 + 4 * (a^8 * r^2 + a^6 * r^4) * cos_theta^6 + 6 * (a^6 * r^4 + a^4 * r^6) * cos_theta^4 + 4 * (a^4 * r^6 + a^2 * r^8) * cos_theta^2 + (2 * M * a^8 * r * cos_theta^6 + 2 * M^3 * a^2 * epsilon * r^4 + M^2 * a^2 * epsilon * r^5 + 2 * M * a^2 * r^7 + (M^2 * a^6 * epsilon * r + 6 * M * a^6 * r^3) * cos_theta^4 + 2 * (M^3 * a^4 * epsilon * r^2 + M^2 * a^4 * epsilon * r^3 + 3 * M * a^4 * r^5) * cos_theta^2) * sin_theta^2)/(M^4*a^2*epsilon^2*r^2+2*M^2*a^2*epsilon*r^5-2*M^3*epsilon*r^6+M^2*epsilon*r^7+a^2*r^8-2*M*r^9+r^10+(a^10-2*M*a^8*r+a^8*r^2)*cos_theta^8-(M^2*a^6*epsilon*r-4*a^8*r^2+8*M*a^6*r^3-4*a^6*r^4)*cos_theta^6+(2*M^2*a^6*epsilon*r-2*M^3*a^4*epsilon*r^2-M^2*a^4*epsilon*r^3+6*a^6*r^4-12*M*a^4*r^5+6*a^4*r^6)*cos_theta^4-(M^4*a^2*epsilon^2*r^2-4*M^2*a^4*epsilon*r^3+4*M^3*a^2*epsilon*r^4-M^2*a^2*epsilon*r^5-4*a^4*r^6+8*M*a^2*r^7-4*a^2*r^8)*cos_theta^2) 0 0 -2*(M*a^3*r*cos_theta^2+M*a*r^3)/(M^2*a^2*epsilon*r+a^2*r^4-2*M*r^5+r^6+(a^6-2*M*a^4*r+a^4*r^2)*cos_theta^4-(M^2*a^2*epsilon*r-2*a^4*r^2+4*M*a^2*r^3-2*a^2*r^4)*cos_theta^2)
+            0 (M^2*a^2*epsilon*r*sin_theta^2+a^2*r^4-2*M*r^5+r^6+(a^6-2*M*a^4*r+a^4*r^2)*cos_theta^4+2*(a^4*r^2-2*M*a^2*r^3+a^2*r^4)*cos_theta^2)/(a^6*cos_theta^6+3*a^4*r^2*cos_theta^4+M^2*epsilon*r^3+r^6+(M^2*a^2*epsilon*r+3*a^2*r^4)*cos_theta^2) 0 0
+            0 0 1/(a^2*cos_theta^2+r^2) 0
+            -2*(M*a^3*r*cos_theta^2+M*a*r^3)/(M^2*a^2*epsilon*r+a^2*r^4-2*M*r^5+r^6+(a^6-2*M*a^4*r+a^4*r^2)*cos_theta^4-(M^2*a^2*epsilon*r-2*a^4*r^2+4*M*a^2*r^3-2*a^2*r^4)*cos_theta^2) 0 0 (a^4*cos_theta^4-2*M*r^3+r^4-2*(M*a^2*r-a^2*r^2)*cos_theta^2)/((2*M*a^4*r*cos_theta^2+M^2*a^2*epsilon*r+2*M*a^2*r^3)*sin_theta^4-(2*M*a^2*r^3-a^2*r^4+2*M*r^5-r^6-(a^6+a^4*r^2)*cos_theta^4+2*(M*a^4*r-a^4*r^2+M*a^2*r^3-a^2*r^4)*cos_theta^2)*sin_theta^2)
+        ]
+    end
+end
+
+
+end # module
+
+@with_kw struct JohannsenPsaltis{T} <: AbstractMetricParams{T}
+    @deftype T
+    M = 1.0
+    a = 0.0
+    epsilon = 0.0
+end
+
+@with_kw struct JohannsenPsaltisJac{T} <: AbstractMetricParams{T}
+    @deftype T
+    M = 1.0
+    a = 0.0
+    epsilon = 0.0
+end
+
+geodesic_eq(m::JohannsenPsaltis{T}, u, v) where {T} =
+    JohannsenPsaltisCoords.geodesic_eq(u, v, m.M, m.a, m.epsilon)
+geodesic_eq(m::JohannsenPsaltisJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+
+constrain(m::JohannsenPsaltis{T}, u, v; μ::T = 0.0) where {T} =
+    JohannsenPsaltisCoords.constrain(μ, u, v, m.M, m.a, m.epsilon)
+
+# specialisations
+metric(m::JohannsenPsaltis{T}, u) where {T} =
+    JohannsenPsaltisCoords.metric(u, m.M, m.a, m.epsilon)
+inverse_metric(m::JohannsenPsaltis{T}, u) where {T} =
+    JohannsenPsaltisCoords.inverse_metric(u, m.M, m.a, m.epsilon)
+jacobian(m::JohannsenPsaltis{T}, u) where {T} =
+    JohannsenPsaltisCoords.jacobian(u, m.M, m.a, m.epsilon)
+metric(m::JohannsenPsaltisJac{T}, u) where {T} =
+    JohannsenPsaltisCoords.metric(u, m.M, m.a, m.epsilon)
+inverse_metric(m::JohannsenPsaltisJac{T}, u) where {T} =
+    JohannsenPsaltisCoords.inverse_metric(u, m.M, m.a, m.epsilon)
+jacobian(m::JohannsenPsaltisJac{T}, u) where {T} =
+    JohannsenPsaltisCoords.jacobian(u, m.M, m.a, m.epsilon)
+
+export JohannsenPsaltisCoords, JohannsenPsaltis, JohannsenPsaltisJac
+
+# additional specializations
+inner_radius(m::JohannsenPsaltis{T}) where {T} = m.M + √(m.M^2 - m.a^2)
+inner_radius(m::JohannsenPsaltisJac{T}) where {T} = m.M + √(m.M^2 - m.a^2)

--- a/src/morris-thorne.jl
+++ b/src/morris-thorne.jl
@@ -3,6 +3,7 @@
 Automatically generated from SageMath calculations
 
 Fergus Baker - 9th Nov 2021
+             - 10th Feb 2022: updated to include Jacobian method
 
 """
 module MorrisThorneCoords
@@ -11,8 +12,8 @@ using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, b)
     ComputedGeodesicEquations.@let_unpack u v begin
-        cos_theta = cos(θ)
-        sin_theta = sin(θ)
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
 
         out1 = 0
         out2 = r * v_phi^2 * sin_theta + r * v_theta^2
@@ -29,8 +30,8 @@ end
 
 @inline function constrain(μ, u, v, b)
     ComputedGeodesicEquations.@let_unpack u v begin
-        cos_theta = cos(θ)
-        sin_theta = sin(θ)
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
 
         sqrt(
             b^2 * v_phi^2 * sin_theta +
@@ -41,6 +42,68 @@ end
     end
 end
 
+@inline function jacobian(u, b)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        comp1 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        comp2 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 2*r 0
+            0 0 0 2*r*sin_theta
+        ]
+        comp3 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 (b^2+r^2)*cos_theta
+        ]
+        comp4 = @SMatrix [
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+            0 0 0 0
+        ]
+        (comp1, comp2, comp3, comp4)
+    end
+end
+
+@inline function metric(u, b)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            -1 0 0 0
+            0 1 0 0
+            0 0 b^2+r^2 0
+            0 0 0 (b^2+r^2)*sin_theta
+        ]
+    end
+end
+
+@inline function inverse_metric(u, b)
+    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+
+        @SMatrix [
+            -1 0 0 0
+            0 1 0 0
+            0 0 1/(b^2+r^2) 0
+            0 0 0 1/((b^2+r^2)*sin_theta)
+        ]
+    end
+end
+
+
 end # module
 
 @with_kw struct MorrisThorne{T} <: AbstractMetricParams{T}
@@ -48,8 +111,24 @@ end # module
     b = 1.0
 end
 
-geodesic_eq(m::MorrisThorne, u, v) = MorrisThorneCoords.geodesic_eq(u, v, m.b)
+@with_kw struct MorrisThorneJac{T} <: AbstractMetricParams{T}
+    @deftype T
+    b = 1.0
+end
+
+geodesic_eq(m::MorrisThorne{T}, u, v) where {T} = MorrisThorneCoords.geodesic_eq(u, v, m.b)
+geodesic_eq(m::MorrisThorneJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+
 constrain(m::MorrisThorne{T}, u, v; μ::T = 0.0) where {T} =
     MorrisThorneCoords.constrain(μ, u, v, m.b)
 
-export MorrisThorneCoords, MorrisThorne
+# specialisations
+metric(m::MorrisThorne{T}, u) where {T} = MorrisThorneCoords.metric(u, m.b)
+inverse_metric(m::MorrisThorne{T}, u) where {T} = MorrisThorneCoords.inverse_metric(u, m.b)
+jacobian(m::MorrisThorne{T}, u) where {T} = MorrisThorneCoords.jacobian(u, m.b)
+metric(m::MorrisThorneJac{T}, u) where {T} = MorrisThorneCoords.metric(u, m.b)
+inverse_metric(m::MorrisThorneJac{T}, u) where {T} =
+    MorrisThorneCoords.inverse_metric(u, m.b)
+jacobian(m::MorrisThorneJac{T}, u) where {T} = MorrisThorneCoords.jacobian(u, m.b)
+
+export MorrisThorneCoords, MorrisThorne, MorrisThorneJac

--- a/src/morris-thorne.jl
+++ b/src/morris-thorne.jl
@@ -47,12 +47,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp1 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         comp2 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
@@ -65,12 +60,7 @@ end
             0 0 0 0
             0 0 0 (b^2+r^2)*cos_theta
         ]
-        comp4 = ComputedGeodesicEquations.@SMatrix [
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-            0 0 0 0
-        ]
+        comp4 = zeros(ComputedGeodesicEquations.SMatrix{4,4,Float64})
         (comp1, comp2, comp3, comp4)
     end
 end
@@ -117,7 +107,7 @@ end
 end
 
 geodesic_eq(m::MorrisThorne{T}, u, v) where {T} = MorrisThorneCoords.geodesic_eq(u, v, m.b)
-geodesic_eq(m::MorrisThorneJac{T}, u, v) where {T} = jac_geodesic_eq(u, v, m)
+geodesic_eq(m::MorrisThorneJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::MorrisThorne{T}, u, v; μ::T = 0.0) where {T} =
     MorrisThorneCoords.constrain(μ, u, v, m.b)

--- a/src/morris-thorne.jl
+++ b/src/morris-thorne.jl
@@ -47,25 +47,25 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        comp1 = @SMatrix [
+        comp1 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 0
         ]
-        comp2 = @SMatrix [
+        comp2 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 2*r 0
             0 0 0 2*r*sin_theta
         ]
-        comp3 = @SMatrix [
+        comp3 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
             0 0 0 (b^2+r^2)*cos_theta
         ]
-        comp4 = @SMatrix [
+        comp4 = ComputedGeodesicEquations.@SMatrix [
             0 0 0 0
             0 0 0 0
             0 0 0 0
@@ -80,7 +80,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             -1 0 0 0
             0 1 0 0
             0 0 b^2+r^2 0
@@ -94,7 +94,7 @@ end
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
-        @SMatrix [
+        ComputedGeodesicEquations.@SMatrix [
             -1 0 0 0
             0 1 0 0
             0 0 1/(b^2+r^2) 0


### PR DESCRIPTION
Generator now also generates metric, inverse metric, and jacobian functions, so that in particularly intractable cases (e.g. Johannsen-Psaltis) we can construct the geodesic equations more on-the-fly, showing nearly 20% performance improvements on micro-benchmarks.

In cases where the geodesic equations are still small (e.g. Kerr Boyer Lindquist), the Jacobian method is slower.

Still many optimizations to be done for both methods
- cache known symbols in geodesic equations

For Jacobian:
- don't loop over values that are known zeros
- rework equations to minimize floating point operations (e.g. rewriting geodesic expression as in GRay2 Chan et al.)