### PR TITLE
Fast Math

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComputedGeodesicEquations"
 uuid = "42910a5e-bdf1-4870-a538-dfa35571a56d"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 GeodesicBase = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -209,6 +209,7 @@ geodesic_eq(m::{name}{{T}}, u, v) where {{T}} = {name}Coords.geodesic_eq(u, v, {
 geodesic_eq(m::{name}Jac{{T}}, u, v) where {{T}} = jac_geodesic_eq(m, u, v)
 
 constrain(m::{name}{{T}}, u, v; μ::T=0.0) where {{T}} = {name}Coords.constrain(μ, u, v, {struct_arguments})
+constrain(m::{name}Jac{{T}}, u, v; μ::T=0.0) where {{T}} = {name}Coords.constrain(μ, u, v, {struct_arguments})
 
 # specialisations
 metric(m::{name}{{T}}, u) where {{T}} = {name}Coords.metric(u, {struct_arguments})

--- a/generator-src/ComputedGeodesicGenerator.py
+++ b/generator-src/ComputedGeodesicGenerator.py
@@ -79,7 +79,7 @@ def make_geodesic_julia_function(geodesic_eqs, *args):
     arguments = ", ".join((str(i) for i in ['u', 'v', *args]))
     
     func = f"""@inline function geodesic_eq({arguments})
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         {cached_funcs}
         {cached_outputs}
         (out1, out2, out3, out4)
@@ -98,7 +98,7 @@ def make_constraint_julia_function(constraint_eq, *args):
     arguments = ", ".join((str(i) for i in ['μ', 'u', 'v', *args]))
     
     func = f"""@inline function constrain({arguments})
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         {cached_funcs}
         {cached_output}
     end
@@ -125,7 +125,7 @@ def make_metric_julia_function(g, name, *args):
     arguments = ", ".join((str(i) for i in ['u', *args]))
 
     func = f"""@inline function {name}({arguments})
-    let t = u[1], r = u[2], theta = u[3], phi = u[4] 
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4] 
         {cached_funcs}
         ComputedGeodesicEquations.@SMatrix {cached_output}
     end
@@ -150,7 +150,7 @@ def make_jacobian_julia_function(jac, *args):
     cached_funcs, cached_output = cache_functions(components)
 
     func = f"""@inline function jacobian({arguments})
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         {cached_funcs}
         {cached_output}
         (comp1, comp2, comp3, comp4)

--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -434,6 +434,8 @@ geodesic_eq(m::BoyerLindquistJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::BoyerLindquist{T}, u, v; μ::T = 0.0) where {T} =
     BoyerLindquistCoords.constrain(μ, u, v, m.M, m.a)
+constrain(m::BoyerLindquistJac{T}, u, v; μ::T = 0.0) where {T} =
+    BoyerLindquistCoords.constrain(μ, u, v, m.M, m.a)
 
 # specialisations
 metric(m::BoyerLindquist{T}, u) where {T} = BoyerLindquistCoords.metric(u, m.M, m.a)

--- a/src/boyer-lindquist.jl
+++ b/src/boyer-lindquist.jl
@@ -11,7 +11,7 @@ module BoyerLindquistCoords
 using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, M, a)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -261,7 +261,7 @@ using ..ComputedGeodesicEquations
 end
 
 @inline function constrain(μ, u, v, M, a)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -363,7 +363,7 @@ end
 end
 
 @inline function jacobian(u, M, a)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -386,7 +386,7 @@ end
 end
 
 @inline function metric(u, M, a)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -400,7 +400,7 @@ end
 end
 
 @inline function inverse_metric(u, M, a)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 

--- a/src/eddington-finkelstein.jl
+++ b/src/eddington-finkelstein.jl
@@ -11,7 +11,7 @@ module EddingtonFinkelsteinCoords
 using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, M)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -36,7 +36,7 @@ using ..ComputedGeodesicEquations
 end
 
 @inline function constrain(μ, u, v, M)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -50,7 +50,7 @@ end
 end
 
 @inline function jacobian(u, M)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -73,7 +73,7 @@ end
 end
 
 @inline function metric(u, M)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 

--- a/src/eddington-finkelstein.jl
+++ b/src/eddington-finkelstein.jl
@@ -119,6 +119,8 @@ geodesic_eq(m::EddingtonFinkelsteinJac{T}, u, v) where {T} = jac_geodesic_eq(m, 
 
 constrain(m::EddingtonFinkelstein{T}, u, v; μ::T = 0.0) where {T} =
     EddingtonFinkelsteinCoords.constrain(μ, u, v, m.M)
+constrain(m::EddingtonFinkelsteinJac{T}, u, v; μ::T = 0.0) where {T} =
+    EddingtonFinkelsteinCoords.constrain(μ, u, v, m.M)
 
 # specialisations
 metric(m::EddingtonFinkelstein{T}, u) where {T} = EddingtonFinkelsteinCoords.metric(u, m.M)

--- a/src/johannsen-psaltis.jl
+++ b/src/johannsen-psaltis.jl
@@ -3205,6 +3205,8 @@ geodesic_eq(m::JohannsenPsaltisJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v
 
 constrain(m::JohannsenPsaltis{T}, u, v; μ::T = 0.0) where {T} =
     JohannsenPsaltisCoords.constrain(μ, u, v, m.M, m.a, m.epsilon)
+constrain(m::JohannsenPsaltisJac{T}, u, v; μ::T = 0.0) where {T} =
+    JohannsenPsaltisCoords.constrain(μ, u, v, m.M, m.a, m.epsilon)
 
 # specialisations
 metric(m::JohannsenPsaltis{T}, u) where {T} =

--- a/src/johannsen-psaltis.jl
+++ b/src/johannsen-psaltis.jl
@@ -12,7 +12,7 @@ module JohannsenPsaltisCoords
 using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, M, a, epsilon)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -2129,7 +2129,7 @@ using ..ComputedGeodesicEquations
 end
 
 @inline function constrain(μ, u, v, M, a, epsilon)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -3132,7 +3132,7 @@ end
 end
 
 @inline function jacobian(u, M, a, epsilon)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -3155,7 +3155,7 @@ end
 end
 
 @inline function metric(u, M, a, epsilon)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -3169,7 +3169,7 @@ end
 end
 
 @inline function inverse_metric(u, M, a, epsilon)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 

--- a/src/morris-thorne.jl
+++ b/src/morris-thorne.jl
@@ -11,7 +11,7 @@ module MorrisThorneCoords
 using ..ComputedGeodesicEquations
 
 @inline function geodesic_eq(u, v, b)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -29,7 +29,7 @@ using ..ComputedGeodesicEquations
 end
 
 @inline function constrain(μ, u, v, b)
-    ComputedGeodesicEquations.@let_unpack u v begin
+    @fastmath ComputedGeodesicEquations.@let_unpack u v begin
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -43,7 +43,7 @@ end
 end
 
 @inline function jacobian(u, b)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -66,7 +66,7 @@ end
 end
 
 @inline function metric(u, b)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 
@@ -80,7 +80,7 @@ end
 end
 
 @inline function inverse_metric(u, b)
-    let t = u[1], r = u[2], theta = u[3], phi = u[4]
+    @fastmath let t = u[1], r = u[2], theta = u[3], phi = u[4]
         cos_theta = cos(theta)
         sin_theta = sin(theta)
 

--- a/src/morris-thorne.jl
+++ b/src/morris-thorne.jl
@@ -111,6 +111,8 @@ geodesic_eq(m::MorrisThorneJac{T}, u, v) where {T} = jac_geodesic_eq(m, u, v)
 
 constrain(m::MorrisThorne{T}, u, v; μ::T = 0.0) where {T} =
     MorrisThorneCoords.constrain(μ, u, v, m.b)
+constrain(m::MorrisThorneJac{T}, u, v; μ::T = 0.0) where {T} =
+    MorrisThorneCoords.constrain(μ, u, v, m.b)
 
 # specialisations
 metric(m::MorrisThorne{T}, u) where {T} = MorrisThorneCoords.metric(u, m.b)


### PR DESCRIPTION
Added `@fastmath` everywhere:
```
2-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "jacobian" => 4-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "boyer-lindquist" => Trial(580.345 μs)
          "johannsen-psaltis" => Trial(655.701 μs)
          "morris-thorne" => Trial(564.569 μs)
          "eddington-finkelstein" => Trial(583.311 μs)
  "regular" => 4-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "boyer-lindquist" => Trial(66.039 μs)
          "johannsen-psaltis" => Trial(792.701 μs)
          "morris-thorne" => Trial(20.382 μs)
          "eddington-finkelstein" => Trial(24.158 μs)
```